### PR TITLE
Fixed Issue with Pip Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'openzeppelin-cairo-contracts',
+        'cairolib'
     ],
 )


### PR DESCRIPTION
We use https://github.com/aspectco/cairo-lib in the compilation of some of our contracts. As we don't install this with our dependencies, it fails to compile.