### PR TITLE
Version 0.2.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @immutable/immutable-x-starknet

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -64,3 +64,18 @@ jobs:
           sleep 15s && echo "sleeping for 15s to let devnet start"
       - name: Run Tests
         run: export REPORT_GAS=true; npm run test
+
+  protostar:
+    name: Run Protostar Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Protostar
+        run: |
+          curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash
+          echo "~/.protostar/dist/protostar/" >> $GITHUB_PATH
+      - name: Run tests
+        run: protostar test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,7 @@
+[submodule "cairo_lib"]
+	url = https://github.com/aspectco/cairo-lib
+	path = lib/cairo_lib
+[submodule "cairo_contracts"]
+	url = https://github.com/OpenZeppelin/cairo-contracts
+	path = lib/cairo_contracts
+	branch = refs/heads/0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,21 @@ Initial release!
 ### Fixed
 
 - Minor README/documentation changes
+
+# [0.2.1] - 2022-07-11
+
+### Added
+
+- Protostar tests
+- Added `IAccessControl_mock.cairo` for testing
+- Added `name()` and `symbol()` to `IERC721` for testing
+
+### Changed
+
+- Upgrade to support OpenZeppelin 0.2.0
+- `IERC2981_Unidirectional_Royalties` is now `IERC721_Unidirectional`
+
+### Fixed
+
+- `PaymentSplitter` now starts index from 0 instead of 1
+- `ERC721_Token_Metadata` now returns empty felt array when both base and token uri are undefined

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Immutable X StarkNet Contracts
 
-We greatly appreciate all community feedback and contributions to this repository. This guide will walk you through the different ways you can contribute, including opening Github issues, pull requests, reporting security issues, requesting features, and providing general feedback.
+We greatly appreciate all community feedback and contributions to this repository. This guide will walk you through the different ways you can contribute, including opening Github issues, pull requests, requesting features, and providing general feedback. For any security disclosures, please email starknet-security@immutable.com
 
 ## Opening an issue
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repository, you will find Cairo implementations of:
 - Metadata standards
 - Royalties
 - Payment Splitter
-- Asset Bridging (L1 ↔︎ L2) (coming soon)
+- Asset Bridging (Arch)
 
 These contracts were designed to be feature-rich recommended standards on StarkNet, generalizable for current and future partner use cases as well as the wider ecosystem. This helps advance the necessary StarkNet primitives for Immutable X's StarkNet strategy and provides easy onboarding with out-of-the-box Cairo contracts to help developers build on StarkNet.
 
@@ -30,11 +30,15 @@ The StarkNet package includes all Cairo contracts for the above implementations.
 
 ## Contribution
 
-We aim to build robust and feature-rich standards to help all developers onboard and build their projects on StarkNet, and we welcome any and all feedback and contributions to this repository! See our [contribution guideline](CONTRIBUTING.md) for more details on opening Github issues, pull requests, reporting security issues, requesting features, and providing general feedback.
+We aim to build robust and feature-rich standards to help all developers onboard and build their projects on StarkNet, and we welcome any and all feedback and contributions to this repository! See our [contribution guideline](CONTRIBUTING.md) for more details on opening Github issues, pull requests requesting features, and providing general feedback.
 
 ## Disclaimers
 
-These Cairo contracts are in a very experimental stage and are subject to change without notice. The code has not yet been formally audited or reviewed and may have security vulnerabilities. Do not use in production.
+These Cairo contracts are in a very experimental stage and are subject to change without notice. The code has not yet been formally audited or reviewed and may have security vulnerabilities. Do not use in production. We take no responsibility for your implementation decisions and any security problems you might experience.
+
+## Security
+
+Please responsibly disclose any security issues you find by reaching out to starknet-security@immutable.com
 
 ## License
 

--- a/immutablex/starknet/README.md
+++ b/immutablex/starknet/README.md
@@ -63,7 +63,7 @@ Create a new file in the `contracts` folder called `MyERC20.cairo`. We import th
 
 %lang starknet
 
-from immutablex.token.erc20.presets.ERC20_Mintable_Capped import constructor
+from immutablex.starknet.token.erc20.presets.ERC20_Mintable_Capped import constructor
 ```
 
 You can add additional functions to your contract as required, as long the function name does not conflict with the existing ERC20 functions.
@@ -116,9 +116,48 @@ Using `hardhat`:
 npx hardhat starknet-deploy --starknet-network alpha --inputs "<name> <symbol> <decimals> <owner> <cap>"
 ```
 
-## Contribution
+<br/>
+<br/>
+
+# Contribution
 
 If you wish to contribute to this repository, please check out our [contribution guidelines](../../CONTRIBUTING.md). To set up the development environment:
+
+## Using Protostar
+
+Protostar is a much more lightweight development environment that is easy to set up and use with minimal effort. Protostar can be used to run unit/functional tests and offers additional functionality through the CLI. See [Protostar documentation here](https://docs.swmansion.com/protostar/docs/tutorials/introduction). No Python virtual environment is required.
+
+### Install Protostar
+
+Copy and run in a terminal the following command:
+
+```
+curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash
+```
+
+You may have to restart the terminal. Run `protostar -v` to check Protostar and cairo-lang version.
+
+### Install dependencies
+
+Run the following command to install dependencies. Protostar currently uses git submodules to handle dependencies.
+
+```
+protostar install
+```
+
+### Run tests
+
+```
+# Run all tests
+protostar test
+
+# Run a specific test
+protostar test ./path/to/test/file.cairo::test_name_here
+```
+
+## Using Hardhat
+
+Hardhat setup will be required to run integration tests and hardhat tests on a local devnet. Hardhat also allows you to write and run scripts to deploy/interact with contracts in Typescript/Javascript.
 
 ### Install Python packages
 
@@ -132,19 +171,19 @@ pip install -r requirements.txt
 
 #### Potential issues with M1 Macs
 
-You will need to use Python 3.10 and Pip 3.10
+You may not have success with every version of Python. Version 3.8 should work out of the box.
 
 To install, run:
 
 ```
-brew install python@3.10
+brew install python@3.8
 python3 -m pip install --upgrade pip # on mac
 ```
 
 Then add this to ~/.zshrc
 
 ```
-export PATH="/opt/homebrew/opt/python@3.10/bin:$PATH"
+export PATH="/opt/homebrew/opt/python@3.8/bin:$PATH"
 ```
 
 Some packages may not install properly when installing or compiling Cairo

--- a/immutablex/starknet/access/AccessControl.cairo
+++ b/immutablex/starknet/access/AccessControl.cairo
@@ -9,7 +9,7 @@ from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.math import assert_not_zero
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
+from openzeppelin.introspection.ERC165 import ERC165
 
 from immutablex.starknet.utils.constants import IACCESSCONTROL_ID
 
@@ -56,7 +56,7 @@ namespace AccessControl:
         default_admin : felt
     ):
         AccessControl._grant_role(DEFAULT_ADMIN_ROLE, default_admin)
-        ERC165_register_interface(IACCESSCONTROL_ID)
+        ERC165.register_interface(IACCESSCONTROL_ID)
         return ()
     end
 

--- a/immutablex/starknet/auxiliary/erc2981/flagged.cairo
+++ b/immutablex/starknet/auxiliary/erc2981/flagged.cairo
@@ -22,8 +22,8 @@ from starkware.cairo.common.uint256 import (
 )
 from starkware.cairo.common.bool import TRUE, FALSE
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
-from openzeppelin.security.safemath import uint256_checked_mul, uint256_checked_div_rem
+from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.security.safemath import SafeUint256
 
 from immutablex.starknet.utils.constants import IERC2981_ID
 
@@ -50,7 +50,7 @@ end
 
 namespace ERC2981_Flagged:
     func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-        ERC165_register_interface(IERC2981_ID)
+        ERC165.register_interface(IERC2981_ID)
         ERC2981_Flagged_mutable.write(TRUE)
         return ()
     end
@@ -76,8 +76,8 @@ namespace ERC2981_Flagged:
         local royalty : RoyaltyInfo = royalty
 
         # royalty_amount = sale_price * fee_basis_points / 10000
-        let (x : Uint256) = uint256_checked_mul(sale_price, Uint256(royalty.fee_basis_points, 0))
-        let (royalty_amount : Uint256, _) = uint256_checked_div_rem(x, Uint256(FEE_DENOMINATOR, 0))
+        let (x : Uint256) = SafeUint256.mul(sale_price, Uint256(royalty.fee_basis_points, 0))
+        let (royalty_amount : Uint256, _) = SafeUint256.div_rem(x, Uint256(FEE_DENOMINATOR, 0))
 
         return (royalty.receiver, royalty_amount)
     end

--- a/immutablex/starknet/auxiliary/erc2981/immutable.cairo
+++ b/immutablex/starknet/auxiliary/erc2981/immutable.cairo
@@ -18,8 +18,8 @@ from starkware.cairo.common.uint256 import (
     uint256_unsigned_div_rem,
 )
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
-from openzeppelin.security.safemath import uint256_checked_mul, uint256_checked_div_rem
+from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.security.safemath import SafeUint256
 
 from immutablex.starknet.utils.constants import IERC2981_ID
 
@@ -40,7 +40,7 @@ namespace ERC2981_Immutable:
     func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         receiver : felt, fee_basis_points : felt
     ):
-        ERC165_register_interface(IERC2981_ID)
+        ERC165.register_interface(IERC2981_ID)
         _set_contract_royalty(receiver, fee_basis_points)
         return ()
     end
@@ -56,8 +56,8 @@ namespace ERC2981_Immutable:
         let (royalty) = ERC2981_Immutable_royalty_info.read()
 
         # royalty_amount = sale_price * fee_basis_points / 10000
-        let (x : Uint256) = uint256_checked_mul(sale_price, Uint256(royalty.fee_basis_points, 0))
-        let (royalty_amount : Uint256, _) = uint256_checked_div_rem(x, Uint256(FEE_DENOMINATOR, 0))
+        let (x : Uint256) = SafeUint256.mul(sale_price, Uint256(royalty.fee_basis_points, 0))
+        let (royalty_amount : Uint256, _) = SafeUint256.div_rem(x, Uint256(FEE_DENOMINATOR, 0))
 
         return (royalty.receiver, royalty_amount)
     end

--- a/immutablex/starknet/auxiliary/erc2981/interfaces/IERC2981_Unidirectional.cairo
+++ b/immutablex/starknet/auxiliary/erc2981/interfaces/IERC2981_Unidirectional.cairo
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache 2.0
+# Immutable Cairo Contracts v0.1.0
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC2981_Unidirectional:
+    func royaltyInfo(tokenId : Uint256, salePrice : Uint256) -> (
+        receiver : felt, royaltyAmount : Uint256
+    ):
+    end
+
+    func getDefaultRoyalty() -> (receiver : felt, feeBasisPoints : felt):
+    end
+
+    func setDefaultRoyalty(receiver : felt, feeBasisPoints : felt):
+    end
+
+    func resetDefaultRoyalty():
+    end
+
+    func setTokenRoyalty(tokenId : Uint256, receiver : felt, feeBasisPoints : felt):
+    end
+
+    func resetTokenRoyalty(tokenId : Uint256):
+    end
+end

--- a/immutablex/starknet/auxiliary/erc2981/mutable.cairo
+++ b/immutablex/starknet/auxiliary/erc2981/mutable.cairo
@@ -18,8 +18,8 @@ from starkware.cairo.common.uint256 import (
     uint256_unsigned_div_rem,
 )
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
-from openzeppelin.security.safemath import uint256_checked_mul, uint256_checked_div_rem
+from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.security.safemath import SafeUint256
 
 from immutablex.starknet.utils.constants import IERC2981_ID
 
@@ -42,7 +42,7 @@ end
 
 namespace ERC2981_Mutable:
     func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-        ERC165_register_interface(IERC2981_ID)
+        ERC165.register_interface(IERC2981_ID)
         return ()
     end
 
@@ -62,8 +62,8 @@ namespace ERC2981_Mutable:
         local royalty : RoyaltyInfo = royalty
 
         # royalty_amount = sale_price * fee_basis_points / 10000
-        let (x : Uint256) = uint256_checked_mul(sale_price, Uint256(royalty.fee_basis_points, 0))
-        let (royalty_amount : Uint256, _) = uint256_checked_div_rem(x, Uint256(FEE_DENOMINATOR, 0))
+        let (x : Uint256) = SafeUint256.mul(sale_price, Uint256(royalty.fee_basis_points, 0))
+        let (royalty_amount : Uint256, _) = SafeUint256.div_rem(x, Uint256(FEE_DENOMINATOR, 0))
 
         return (royalty.receiver, royalty_amount)
     end

--- a/immutablex/starknet/auxiliary/erc2981/unidirectional_mutable.cairo
+++ b/immutablex/starknet/auxiliary/erc2981/unidirectional_mutable.cairo
@@ -20,8 +20,8 @@ from starkware.cairo.common.uint256 import (
     uint256_unsigned_div_rem,
 )
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
-from openzeppelin.security.safemath import uint256_checked_mul, uint256_checked_div_rem
+from openzeppelin.introspection.ERC165 import ERC165
+from openzeppelin.security.safemath import SafeUint256
 
 from immutablex.starknet.utils.constants import IERC2981_ID
 
@@ -48,7 +48,7 @@ namespace ERC2981_UniDirectional_Mutable:
     func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         receiver : felt, fee_basis_points : felt
     ):
-        ERC165_register_interface(IERC2981_ID)
+        ERC165.register_interface(IERC2981_ID)
         with_attr error_message(
                 "ERC2981_UniDirectional_Mutable: fee_basis_points exceeds fee denominator (10000)"):
             assert_le_felt(fee_basis_points, FEE_DENOMINATOR)
@@ -76,8 +76,8 @@ namespace ERC2981_UniDirectional_Mutable:
         local royalty : RoyaltyInfo = royalty
 
         # royalty_amount = sale_price * fee_basis_points / 10000
-        let (x : Uint256) = uint256_checked_mul(sale_price, Uint256(royalty.fee_basis_points, 0))
-        let (royalty_amount : Uint256, _) = uint256_checked_div_rem(x, Uint256(FEE_DENOMINATOR, 0))
+        let (x : Uint256) = SafeUint256.mul(sale_price, Uint256(royalty.fee_basis_points, 0))
+        let (royalty_amount : Uint256, _) = SafeUint256.div_rem(x, Uint256(FEE_DENOMINATOR, 0))
 
         return (royalty.receiver, royalty_amount)
     end

--- a/immutablex/starknet/auxiliary/supply/capped.cairo
+++ b/immutablex/starknet/auxiliary/supply/capped.cairo
@@ -8,7 +8,7 @@ from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.uint256 import Uint256, uint256_le, uint256_lt, uint256_check
 from starkware.cairo.common.bool import FALSE
 
-from openzeppelin.security.safemath import uint256_checked_add
+from openzeppelin.security.safemath import SafeUint256
 
 @storage_var
 func _cap() -> (cap : Uint256):
@@ -34,7 +34,7 @@ namespace Capped:
     ):
         alloc_locals
         with_attr error_message("Capped: supply overflow"):
-            let (new_supply : Uint256) = uint256_checked_add(total_supply, amount)
+            let (new_supply : Uint256) = SafeUint256.add(total_supply, amount)
         end
         # check new_supply <= cap
         let (cap : Uint256) = _cap.read()

--- a/immutablex/starknet/bridge/StandardERC721Bridge.cairo
+++ b/immutablex/starknet/bridge/StandardERC721Bridge.cairo
@@ -7,7 +7,7 @@ from starkware.starknet.common.messages import send_message_to_l1
 from starkware.cairo.common.uint256 import Uint256, uint256_check
 from starkware.cairo.common.math import assert_not_zero
 
-from openzeppelin.access.ownable import Ownable_initializer, Ownable_only_owner
+from openzeppelin.access.ownable import Ownable
 
 from immutablex.starknet.token.erc721.interfaces.IERC721 import IERC721
 from immutablex.starknet.bridge.interfaces.IERC721_Bridgeable import IERC721_Bridgeable
@@ -25,7 +25,7 @@ end
 # TODO: l1 handler to register pair of addresses, ownable + ability to change l1 bridge/upgrade?
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(owner : felt):
-    Ownable_initializer(owner)
+    Ownable.initializer(owner)
     return ()
 end
 
@@ -57,7 +57,7 @@ end
 func set_l1_bridge{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     l1_bridge_address : felt
 ):
-    Ownable_only_owner()
+    Ownable.assert_only_owner()
     _l1_bridge.write(l1_bridge_address)
     return ()
 end

--- a/immutablex/starknet/finance/PaymentSplitter.cairo
+++ b/immutablex/starknet/finance/PaymentSplitter.cairo
@@ -9,12 +9,7 @@ from starkware.cairo.common.math import assert_not_zero, assert_lt
 from starkware.cairo.common.uint256 import Uint256, uint256_lt
 
 from openzeppelin.token.erc20.interfaces.IERC20 import IERC20
-from openzeppelin.security.safemath import (
-    uint256_checked_mul,
-    uint256_checked_div_rem,
-    uint256_checked_add,
-    uint256_checked_sub_le,
-)
+from openzeppelin.security.safemath import SafeUint256
 
 #
 # Events
@@ -158,12 +153,12 @@ func release{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
 
     # Update payee released
     let (already_released : Uint256) = _released.read(token, payee)
-    let (new_released : Uint256) = uint256_checked_add(payment, already_released)
+    let (new_released : Uint256) = SafeUint256.add(payment, already_released)
     _released.write(token, payee, new_released)
 
     # Update total released
     let (total_released : Uint256) = _total_released.read(token)
-    let (new_total_released : Uint256) = uint256_checked_add(payment, total_released)
+    let (new_total_released : Uint256) = SafeUint256.add(payment, total_released)
     _total_released.write(token, new_total_released)
 
     # Transfer the ERC20 tokens to payee
@@ -193,7 +188,7 @@ func _add_payees{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     end
 
     # add payees
-    _payees.write(payees_len, [payees])
+    _payees.write(payees_len - 1, [payees])
     # add new shares to total shares
     let (total_shares) = _total_shares.read()
     _total_shares.write(total_shares + [shares])
@@ -217,14 +212,14 @@ func _get_pending_payment{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, rang
     # total tokens received by contract = current contract balance + released tokens
     let (contract_balance) = _get_balance(token)
     let (total_released : Uint256) = _total_released.read(token)
-    let (total_received : Uint256) = uint256_checked_add(contract_balance, total_released)
+    let (total_received : Uint256) = SafeUint256.add(contract_balance, total_released)
     let (already_released : Uint256) = _released.read(token, payee)
 
     # calculate pending payment
     # (total_received * (shares / total_shares)) - already_released
-    let (x : Uint256) = uint256_checked_mul(total_received, Uint256(shares, 0))
-    let (total_owed : Uint256, _) = uint256_checked_div_rem(x, Uint256(total_shares, 0))
-    let (pending_payment) = uint256_checked_sub_le(total_owed, already_released)
+    let (x : Uint256) = SafeUint256.mul(total_received, Uint256(shares, 0))
+    let (total_owed : Uint256, _) = SafeUint256.div_rem(x, Uint256(total_shares, 0))
+    let (pending_payment) = SafeUint256.sub_le(total_owed, already_released)
     return (pending_payment)
 end
 
@@ -232,8 +227,7 @@ func _get_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     token : felt
 ) -> (balance : Uint256):
     let (contract_address) = get_contract_address()
-    with_attr error_message(
-            "PaymentSplitter: Failed to call balanceOf on contract {contract_address}"):
+    with_attr error_message("PaymentSplitter: Failed to call balanceOf on token contract"):
         let (balance) = IERC20.balanceOf(token, contract_address)
     end
     return (balance)

--- a/immutablex/starknet/mocks/ERC721Receiver_mock.cairo
+++ b/immutablex/starknet/mocks/ERC721Receiver_mock.cairo
@@ -5,13 +5,13 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface, ERC165_supports_interface
+from openzeppelin.introspection.ERC165 import ERC165
 
 from immutablex.starknet.utils.constants import IERC721_RECEIVER_ID
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
-    ERC165_register_interface(IERC721_RECEIVER_ID)
+    ERC165.register_interface(IERC721_RECEIVER_ID)
     return ()
 end
 
@@ -19,7 +19,7 @@ end
 func supportsInterface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     interfaceId : felt
 ) -> (success : felt):
-    let (success) = ERC165_supports_interface(interfaceId)
+    let (success) = ERC165.supports_interface(interfaceId)
     return (success)
 end
 

--- a/immutablex/starknet/mocks/IAccessControl_mock.cairo
+++ b/immutablex/starknet/mocks/IAccessControl_mock.cairo
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache 2.0
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IAccessControl:
+    func has_role(role : felt, account : felt) -> (res : felt):
+    end
+
+    func get_role_admin(role : felt) -> (role_admin : felt):
+    end
+
+    func grant_role(role : felt, account : felt):
+    end
+
+    func revoke_role(role : felt, account : felt):
+    end
+
+    func renounce_role(role : felt, account : felt):
+    end
+
+    func set_role_admin(role : felt, admin_role : felt):
+    end
+end

--- a/immutablex/starknet/token/erc20/presets/ERC20_Mintable_Capped.cairo
+++ b/immutablex/starknet/token/erc20/presets/ERC20_Mintable_Capped.cairo
@@ -8,27 +8,8 @@ from starkware.cairo.common.uint256 import Uint256, uint256_check, uint256_add, 
 from starkware.cairo.common.math import assert_not_zero
 from starkware.cairo.common.bool import TRUE
 
-from openzeppelin.access.ownable import (
-    Ownable_initializer,
-    Ownable_only_owner,
-    Ownable_get_owner,
-    Ownable_transfer_ownership,
-)
-from openzeppelin.token.erc20.library import (
-    ERC20_name,
-    ERC20_symbol,
-    ERC20_totalSupply,
-    ERC20_decimals,
-    ERC20_balanceOf,
-    ERC20_allowance,
-    ERC20_initializer,
-    ERC20_approve,
-    ERC20_increaseAllowance,
-    ERC20_decreaseAllowance,
-    ERC20_transfer,
-    ERC20_transferFrom,
-    ERC20_mint,
-)
+from openzeppelin.access.ownable import Ownable
+from openzeppelin.token.erc20.library import ERC20
 
 from immutablex.starknet.auxiliary.supply.capped import Capped
 
@@ -37,8 +18,8 @@ func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_p
     name : felt, symbol : felt, decimals : felt, owner : felt, cap : Uint256
 ):
     Capped.initializer(cap)
-    ERC20_initializer(name, symbol, decimals)
-    Ownable_initializer(owner)
+    ERC20.initializer(name, symbol, decimals)
+    Ownable.initializer(owner)
     return ()
 end
 
@@ -48,13 +29,13 @@ end
 
 @view
 func name{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (name : felt):
-    let (name) = ERC20_name()
+    let (name) = ERC20.name()
     return (name)
 end
 
 @view
 func symbol{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (symbol : felt):
-    let (symbol) = ERC20_symbol()
+    let (symbol) = ERC20.symbol()
     return (symbol)
 end
 
@@ -62,7 +43,7 @@ end
 func totalSupply{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     totalSupply : Uint256
 ):
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     return (totalSupply)
 end
 
@@ -70,7 +51,7 @@ end
 func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
     decimals : felt
 ):
-    let (decimals) = ERC20_decimals()
+    let (decimals) = ERC20.decimals()
     return (decimals)
 end
 
@@ -78,7 +59,7 @@ end
 func balanceOf{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     account : felt
 ) -> (balance : Uint256):
-    let (balance : Uint256) = ERC20_balanceOf(account)
+    let (balance : Uint256) = ERC20.balance_of(account)
     return (balance)
 end
 
@@ -86,13 +67,13 @@ end
 func allowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     owner : felt, spender : felt
 ) -> (remaining : Uint256):
-    let (remaining : Uint256) = ERC20_allowance(owner, spender)
+    let (remaining : Uint256) = ERC20.allowance(owner, spender)
     return (remaining)
 end
 
 @view
 func owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (owner : felt):
-    let (owner : felt) = Ownable_get_owner()
+    let (owner : felt) = Ownable.owner()
     return (owner)
 end
 
@@ -110,7 +91,7 @@ end
 func transfer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transfer(recipient, amount)
+    ERC20.transfer(recipient, amount)
     return (TRUE)
 end
 
@@ -118,7 +99,7 @@ end
 func transferFrom{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     sender : felt, recipient : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_transferFrom(sender, recipient, amount)
+    ERC20.transfer_from(sender, recipient, amount)
     return (TRUE)
 end
 
@@ -126,7 +107,7 @@ end
 func approve{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, amount : Uint256
 ) -> (success : felt):
-    ERC20_approve(spender, amount)
+    ERC20.approve(spender, amount)
     return (TRUE)
 end
 
@@ -134,7 +115,7 @@ end
 func increaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, added_value : Uint256
 ) -> (success : felt):
-    ERC20_increaseAllowance(spender, added_value)
+    ERC20.increase_allowance(spender, added_value)
     return (TRUE)
 end
 
@@ -142,7 +123,7 @@ end
 func decreaseAllowance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     spender : felt, subtracted_value : Uint256
 ) -> (success : felt):
-    ERC20_decreaseAllowance(spender, subtracted_value)
+    ERC20.decrease_allowance(spender, subtracted_value)
     return (TRUE)
 end
 
@@ -150,7 +131,7 @@ end
 func transferOwnership{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     new_owner : felt
 ) -> (success : felt):
-    Ownable_transfer_ownership(new_owner)
+    Ownable.transfer_ownership(new_owner)
     return (TRUE)
 end
 
@@ -158,9 +139,9 @@ end
 func mint{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     to : felt, amount : Uint256
 ) -> (success : felt):
-    Ownable_only_owner()
-    let (totalSupply : Uint256) = ERC20_totalSupply()
+    Ownable.assert_only_owner()
+    let (totalSupply : Uint256) = ERC20.total_supply()
     Capped.check_cap_exceeded(totalSupply, amount)
-    ERC20_mint(to, amount)
+    ERC20._mint(to, amount)
     return (TRUE)
 end

--- a/immutablex/starknet/token/erc721/interfaces/IERC721.cairo
+++ b/immutablex/starknet/token/erc721/interfaces/IERC721.cairo
@@ -7,6 +7,12 @@ from starkware.cairo.common.uint256 import Uint256
 
 @contract_interface
 namespace IERC721:
+    func name() -> (name : felt):
+    end
+
+    func symbol() -> (symbol : felt):
+    end
+
     func balanceOf(owner : felt) -> (balance : Uint256):
     end
 
@@ -21,7 +27,7 @@ namespace IERC721:
     func transferFrom(from_ : felt, to : felt, tokenId : Uint256):
     end
 
-    func approve(approved : felt, tokenId : Uint256):
+    func approve(to : felt, tokenId : Uint256):
     end
 
     func setApprovalForAll(operator : felt, approved : felt):

--- a/immutablex/starknet/token/erc721/library.cairo
+++ b/immutablex/starknet/token/erc721/library.cairo
@@ -12,9 +12,9 @@ from starkware.cairo.common.uint256 import Uint256, uint256_check
 from starkware.cairo.common.bool import TRUE, FALSE
 
 from openzeppelin.introspection.IERC165 import IERC165
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
+from openzeppelin.introspection.ERC165 import ERC165
 from openzeppelin.token.erc721.interfaces.IERC721_Receiver import IERC721_Receiver
-from openzeppelin.security.safemath import uint256_checked_add, uint256_checked_sub_le
+from openzeppelin.security.safemath import SafeUint256
 
 from immutablex.starknet.utils.constants import (
     IERC721_ID,
@@ -78,9 +78,9 @@ namespace ERC721:
         ERC721_name.write(name)
         ERC721_symbol.write(symbol)
         # register IERC721
-        ERC165_register_interface(IERC721_ID)
+        ERC165.register_interface(IERC721_ID)
         # register IERC721_Metadata
-        ERC165_register_interface(IERC721_METADATA_ID)
+        ERC165.register_interface(IERC721_METADATA_ID)
         return ()
     end
 
@@ -339,12 +339,12 @@ namespace ERC721:
 
         # Decrease owner balance
         let (owner_bal) = ERC721_balances.read(from_)
-        let (new_balance : Uint256) = uint256_checked_sub_le(owner_bal, Uint256(1, 0))
+        let (new_balance : Uint256) = SafeUint256.sub_le(owner_bal, Uint256(1, 0))
         ERC721_balances.write(from_, new_balance)
 
         # Increase receiver balance
         let (receiver_bal) = ERC721_balances.read(to)
-        let (new_balance : Uint256) = uint256_checked_add(receiver_bal, Uint256(1, 0))
+        let (new_balance : Uint256) = SafeUint256.add(receiver_bal, Uint256(1, 0))
         ERC721_balances.write(to, new_balance)
 
         # Update token_id owner
@@ -382,7 +382,7 @@ namespace ERC721:
         end
 
         let (balance : Uint256) = ERC721_balances.read(to)
-        let (new_balance : Uint256) = uint256_checked_add(balance, Uint256(1, 0))
+        let (new_balance : Uint256) = SafeUint256.add(balance, Uint256(1, 0))
         ERC721_balances.write(to, new_balance)
         ERC721_owners.write(token_id, to)
         Transfer.emit(0, to, token_id)
@@ -418,7 +418,7 @@ namespace ERC721:
 
         # Decrease owner balance
         let (balance : Uint256) = ERC721_balances.read(owner)
-        let (new_balance : Uint256) = uint256_checked_sub_le(balance, Uint256(1, 0))
+        let (new_balance : Uint256) = SafeUint256.sub_le(balance, Uint256(1, 0))
         ERC721_balances.write(owner, new_balance)
 
         # Delete owner

--- a/immutablex/starknet/token/erc721/presets/ERC721_Full.cairo
+++ b/immutablex/starknet/token/erc721/presets/ERC721_Full.cairo
@@ -11,7 +11,7 @@ from starkware.cairo.common.uint256 import Uint256
 from starkware.cairo.common.bool import TRUE
 from starkware.starknet.common.syscalls import get_caller_address
 
-from openzeppelin.introspection.ERC165 import ERC165_supports_interface
+from openzeppelin.introspection.ERC165 import ERC165
 
 from immutablex.starknet.token.erc721.library import ERC721
 from immutablex.starknet.token.erc721_token_metadata.library import ERC721_Token_Metadata
@@ -57,7 +57,7 @@ end
 func supportsInterface{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     interfaceId : felt
 ) -> (success : felt):
-    let (success) = ERC165_supports_interface(interfaceId)
+    let (success) = ERC165.supports_interface(interfaceId)
     return (success)
 end
 

--- a/immutablex/starknet/token/erc721_token_metadata/library.cairo
+++ b/immutablex/starknet/token/erc721_token_metadata/library.cairo
@@ -11,7 +11,7 @@ from starkware.cairo.common.bool import TRUE, FALSE
 from cairolib.array import arr_concat
 from cairolib.shortstring import uint256_to_ss
 
-from openzeppelin.introspection.ERC165 import ERC165_register_interface
+from openzeppelin.introspection.ERC165 import ERC165
 
 from immutablex.starknet.token.erc721.library import ERC721
 from immutablex.starknet.utils.constants import IERC721_METADATA_ID
@@ -43,7 +43,7 @@ namespace ERC721_Token_Metadata:
 
     func initializer{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
         # register IERC721_Metadata
-        ERC165_register_interface(IERC721_METADATA_ID)
+        ERC165.register_interface(IERC721_METADATA_ID)
         return ()
     end
 
@@ -76,18 +76,22 @@ namespace ERC721_Token_Metadata:
             return (token_uri_len, token_uri_value)
         end
 
-        # We use the baseURI set by the owner, returning concat(baseURI,tokenId)
         let (local base_token_uri) = alloc()
         let (local base_token_uri_len) = ERC721_base_token_uri_len.read()
+        if base_token_uri_len != 0:
+            # We use the baseURI set by the owner, returning concat(baseURI,tokenId)
+            _base_token_uri(base_token_uri_len, base_token_uri)
 
-        _base_token_uri(base_token_uri_len, base_token_uri)
+            let (token_id_ss_len, token_id_ss) = uint256_to_ss(token_id)
+            let (token_uri_len, token_uri) = arr_concat(
+                base_token_uri_len, base_token_uri, token_id_ss_len, token_id_ss
+            )
 
-        let (token_id_ss_len, token_id_ss) = uint256_to_ss(token_id)
-        let (token_uri_len, token_uri) = arr_concat(
-            base_token_uri_len, base_token_uri, token_id_ss_len, token_id_ss
-        )
+            return (token_uri_len, token_uri)
+        end
 
-        return (token_uri_len, token_uri)
+        # If both base_token_uri and token_uri are undefined, return empty array
+        return (0, base_token_uri)
     end
 
     #

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@imtbl/starknet",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@imtbl/starknet",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts-upgradeable": "^4.5.2",
         "bn.js": "^4.12.0",
-        "dotenv": "16.0.0",
-        "starknet": "^3.9.0"
+        "dotenv": "16.0.0"
       },
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.5",
@@ -630,6 +629,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.0.tgz",
       "integrity": "sha512-AhVByTwdXCc2YQ20v300w6KVHle9g2OFc28ZAFCPnJyEpkv1xKXjZcSTgWOlv1i+0dqlgF8RCF2Rn2KC1t+1Vg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -656,6 +656,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
       "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -680,6 +681,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz",
       "integrity": "sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -702,6 +704,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
       "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -724,6 +727,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
       "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -762,6 +766,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
       "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -782,6 +787,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.0.tgz",
       "integrity": "sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -800,6 +806,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
       "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -846,6 +853,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
       "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -932,6 +940,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
       "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -951,6 +960,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
       "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -966,6 +976,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.0.tgz",
       "integrity": "sha512-DaVzgyThzHgSDLuURhvkp4oviGoGe9iTZW4jMEORHDRCgSZ9K9THGFKqL+qGXqPAYLEgZTf5z2w56mRrPR1MjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1004,6 +1015,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
       "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1079,6 +1091,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
       "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1119,6 +1132,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.0.tgz",
       "integrity": "sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1166,6 +1180,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
       "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1186,6 +1201,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.0.tgz",
       "integrity": "sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1266,6 +1282,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
       "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1331,6 +1348,7 @@
       "version": "6.28.2",
       "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-6.28.2.tgz",
       "integrity": "sha512-i+33VVNE+54HrC0mHly6JXWO6Th+/7n7vNpxjhUQq+1IL3K/ex1HUCwB61O/siDInjq7OZ1Roq9CEx7tAsED2Q==",
+      "dev": true,
       "dependencies": {
         "invariant": "2"
       }
@@ -1339,6 +1357,7 @@
       "version": "6.27.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.27.1.tgz",
       "integrity": "sha512-jX++oy89jtv7Dp2X6gwt3MMkoajel80JFWcdc0HCouwDsV1mVJ3SQdwl/bQU0zd8HI6KebvUP95QTwbQLLK/RQ==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/errors": "^6.10.0",
         "@ledgerhq/logs": "^6.10.0",
@@ -1350,6 +1369,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1361,6 +1381,7 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1374,17 +1395,20 @@
     "node_modules/@ledgerhq/devices/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@ledgerhq/errors": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.0.tgz",
-      "integrity": "sha512-fQFnl2VIXh9Yd41lGjReCeK+Q2hwxQJvLZfqHnKqWapTz68NHOv5QcI0OHuZVNEbv0xhgdLhi5b65kgYeQSUVg=="
+      "integrity": "sha512-fQFnl2VIXh9Yd41lGjReCeK+Q2hwxQJvLZfqHnKqWapTz68NHOv5QcI0OHuZVNEbv0xhgdLhi5b65kgYeQSUVg==",
+      "dev": true
     },
     "node_modules/@ledgerhq/hw-app-eth": {
       "version": "6.28.2",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-6.28.2.tgz",
       "integrity": "sha512-/pGJW5QKsci5mkjcUeP8RvDw4sV9gldp7RWKTKlkldqeRh2kV75bAdStL2p99fGdDfGkfYotpTfm3oOXQpOwiQ==",
+      "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/rlp": "^5.5.0",
@@ -1400,6 +1424,7 @@
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.8"
       }
@@ -1408,6 +1433,7 @@
       "version": "6.27.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.27.1.tgz",
       "integrity": "sha512-hnE4/Fq1YzQI4PA1W0H8tCkI99R3UWDb3pJeZd6/Xs4Qw/q1uiQO+vNLC6KIPPhK0IajUfuI/P2jk0qWcMsuAQ==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -1418,6 +1444,7 @@
       "version": "6.27.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.1.tgz",
       "integrity": "sha512-u74rBYlibpbyGblSn74fRs2pMM19gEAkYhfVibq0RE1GNFjxDMFC1n7Sb+93Jqmz8flyfB4UFJsxs8/l1tm2Kw==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -1428,7 +1455,8 @@
     "node_modules/@ledgerhq/logs": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.0.tgz",
-      "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw=="
+      "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw==",
+      "dev": true
     },
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.0",
@@ -1473,12 +1501,14 @@
     "node_modules/@noble/hashes": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-0.5.9.tgz",
-      "integrity": "sha512-7lN1Qh6d8DUGmfN36XRsbN/WcGIPNtTGhkw26vWId/DlCIGsYJJootTtPGghTLcn/AaXPx2Q0b3cacrwXa7OVw=="
+      "integrity": "sha512-7lN1Qh6d8DUGmfN36XRsbN/WcGIPNtTGhkw26vWId/DlCIGsYJJootTtPGghTLcn/AaXPx2Q0b3cacrwXa7OVw==",
+      "dev": true
     },
     "node_modules/@noble/secp256k1": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
       "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3704,6 +3734,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
       "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -3914,7 +3945,8 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -5200,6 +5232,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -6934,6 +6967,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -7319,6 +7353,7 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -17325,6 +17360,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -17343,6 +17379,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -17553,7 +17590,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -17713,6 +17751,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -18199,12 +18238,14 @@
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -18229,6 +18270,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -18636,6 +18678,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -18813,7 +18856,8 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/micro-base/-/micro-base-0.10.2.tgz",
       "integrity": "sha512-lqqJrT7lfJtDmmiQ4zRLZuIJBk96t0RAc5pCrrWpL9zDeH5i/SUL85mku9HqzTI/OCZ8EQ3aicbMW+eK5Nyu5w==",
-      "deprecated": "Switch to @scure/base for audited version of the lib & updates"
+      "deprecated": "Switch to @scure/base for audited version of the lib & updates",
+      "dev": true
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
@@ -18904,12 +18948,14 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -19689,7 +19735,8 @@
     "node_modules/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "dev": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -20872,6 +20919,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -22240,6 +22288,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/starknet/-/starknet-3.9.0.tgz",
       "integrity": "sha512-/sn3WHFX7f+A3vVf3I+Kamg2KIW6494vpCcZWA09IQ5RZXrozjaBtYWT41SoKKWZ3b0Xg8WF//SOkRVCTZOZkQ==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/hw-app-eth": "^6.26.0",
         "@ledgerhq/hw-transport": "^6.24.1",
@@ -22260,6 +22309,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
       "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
       }
@@ -22267,12 +22317,14 @@
     "node_modules/starknet/node_modules/bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "dev": true
     },
     "node_modules/starknet/node_modules/ethereum-cryptography": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.2.5.tgz",
       "integrity": "sha512-aWvqiegXgSTwbuDE1DDnM7taLteLcHVHh5nMZnnD2dwlvH6w5bOxcdXW20oS+1aLDorDlrK1c82stB8jsLDN5Q==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "^0.5.7",
         "@noble/secp256k1": "^1.4.0",
@@ -22424,7 +22476,8 @@
     "node_modules/superstruct": {
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.4.tgz",
-      "integrity": "sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw=="
+      "integrity": "sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw==",
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -23093,7 +23146,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsort": {
       "version": "0.0.1",
@@ -23345,7 +23399,8 @@
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
@@ -25312,6 +25367,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.0.tgz",
       "integrity": "sha512-AhVByTwdXCc2YQ20v300w6KVHle9g2OFc28ZAFCPnJyEpkv1xKXjZcSTgWOlv1i+0dqlgF8RCF2Rn2KC1t+1Vg==",
+      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.6.0",
         "@ethersproject/bignumber": "^5.6.0",
@@ -25328,6 +25384,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
       "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.0",
         "@ethersproject/bytes": "^5.6.0",
@@ -25342,6 +25399,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz",
       "integrity": "sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.0",
         "@ethersproject/bignumber": "^5.6.0",
@@ -25354,6 +25412,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
       "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.0",
         "@ethersproject/bytes": "^5.6.0",
@@ -25366,6 +25425,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
       "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.0"
       }
@@ -25384,6 +25444,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
       "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/logger": "^5.6.0",
@@ -25394,6 +25455,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.0.tgz",
       "integrity": "sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -25402,6 +25464,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
       "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.0"
       }
@@ -25428,6 +25491,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
       "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.0",
         "@ethersproject/address": "^5.6.0",
@@ -25484,6 +25548,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
       "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.0",
         "js-sha3": "0.8.0"
@@ -25492,12 +25557,14 @@
     "@ethersproject/logger": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "dev": true
     },
     "@ethersproject/networks": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.0.tgz",
       "integrity": "sha512-DaVzgyThzHgSDLuURhvkp4oviGoGe9iTZW4jMEORHDRCgSZ9K9THGFKqL+qGXqPAYLEgZTf5z2w56mRrPR1MjQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -25516,6 +25583,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
       "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -25561,6 +25629,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
       "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/logger": "^5.6.0"
@@ -25581,6 +25650,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.0.tgz",
       "integrity": "sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/logger": "^5.6.0",
@@ -25608,6 +25678,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
       "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/constants": "^5.6.0",
@@ -25618,6 +25689,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.0.tgz",
       "integrity": "sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==",
+      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.6.0",
         "@ethersproject/bignumber": "^5.6.0",
@@ -25668,6 +25740,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
       "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
+      "dev": true,
       "requires": {
         "@ethersproject/base64": "^5.6.0",
         "@ethersproject/bytes": "^5.6.0",
@@ -25710,6 +25783,7 @@
       "version": "6.28.2",
       "resolved": "https://registry.npmjs.org/@ledgerhq/cryptoassets/-/cryptoassets-6.28.2.tgz",
       "integrity": "sha512-i+33VVNE+54HrC0mHly6JXWO6Th+/7n7vNpxjhUQq+1IL3K/ex1HUCwB61O/siDInjq7OZ1Roq9CEx7tAsED2Q==",
+      "dev": true,
       "requires": {
         "invariant": "2"
       }
@@ -25718,6 +25792,7 @@
       "version": "6.27.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.27.1.tgz",
       "integrity": "sha512-jX++oy89jtv7Dp2X6gwt3MMkoajel80JFWcdc0HCouwDsV1mVJ3SQdwl/bQU0zd8HI6KebvUP95QTwbQLLK/RQ==",
+      "dev": true,
       "requires": {
         "@ledgerhq/errors": "^6.10.0",
         "@ledgerhq/logs": "^6.10.0",
@@ -25729,6 +25804,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -25737,6 +25813,7 @@
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
           "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -25744,19 +25821,22 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
     "@ledgerhq/errors": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.0.tgz",
-      "integrity": "sha512-fQFnl2VIXh9Yd41lGjReCeK+Q2hwxQJvLZfqHnKqWapTz68NHOv5QcI0OHuZVNEbv0xhgdLhi5b65kgYeQSUVg=="
+      "integrity": "sha512-fQFnl2VIXh9Yd41lGjReCeK+Q2hwxQJvLZfqHnKqWapTz68NHOv5QcI0OHuZVNEbv0xhgdLhi5b65kgYeQSUVg==",
+      "dev": true
     },
     "@ledgerhq/hw-app-eth": {
       "version": "6.28.2",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-6.28.2.tgz",
       "integrity": "sha512-/pGJW5QKsci5mkjcUeP8RvDw4sV9gldp7RWKTKlkldqeRh2kV75bAdStL2p99fGdDfGkfYotpTfm3oOXQpOwiQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/rlp": "^5.5.0",
@@ -25772,6 +25852,7 @@
           "version": "0.26.1",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
           "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
           "requires": {
             "follow-redirects": "^1.14.8"
           }
@@ -25782,6 +25863,7 @@
       "version": "6.27.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.27.1.tgz",
       "integrity": "sha512-hnE4/Fq1YzQI4PA1W0H8tCkI99R3UWDb3pJeZd6/Xs4Qw/q1uiQO+vNLC6KIPPhK0IajUfuI/P2jk0qWcMsuAQ==",
+      "dev": true,
       "requires": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -25792,6 +25874,7 @@
       "version": "6.27.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.1.tgz",
       "integrity": "sha512-u74rBYlibpbyGblSn74fRs2pMM19gEAkYhfVibq0RE1GNFjxDMFC1n7Sb+93Jqmz8flyfB4UFJsxs8/l1tm2Kw==",
+      "dev": true,
       "requires": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -25802,7 +25885,8 @@
     "@ledgerhq/logs": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.0.tgz",
-      "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw=="
+      "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw==",
+      "dev": true
     },
     "@metamask/eth-sig-util": {
       "version": "4.0.0",
@@ -25846,12 +25930,14 @@
     "@noble/hashes": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-0.5.9.tgz",
-      "integrity": "sha512-7lN1Qh6d8DUGmfN36XRsbN/WcGIPNtTGhkw26vWId/DlCIGsYJJootTtPGghTLcn/AaXPx2Q0b3cacrwXa7OVw=="
+      "integrity": "sha512-7lN1Qh6d8DUGmfN36XRsbN/WcGIPNtTGhkw26vWId/DlCIGsYJJootTtPGghTLcn/AaXPx2Q0b3cacrwXa7OVw==",
+      "dev": true
     },
     "@noble/secp256k1": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
-      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ=="
+      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -27680,7 +27766,8 @@
     "bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -27865,7 +27952,8 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -28941,6 +29029,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -30312,7 +30401,8 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -30638,7 +30728,8 @@
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -38325,6 +38416,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -38340,6 +38432,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -38504,7 +38597,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -38633,6 +38727,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -38960,12 +39055,14 @@
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -38987,6 +39084,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0"
       }
@@ -39317,6 +39415,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -39468,7 +39567,8 @@
     "micro-base": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/micro-base/-/micro-base-0.10.2.tgz",
-      "integrity": "sha512-lqqJrT7lfJtDmmiQ4zRLZuIJBk96t0RAc5pCrrWpL9zDeH5i/SUL85mku9HqzTI/OCZ8EQ3aicbMW+eK5Nyu5w=="
+      "integrity": "sha512-lqqJrT7lfJtDmmiQ4zRLZuIJBk96t0RAc5pCrrWpL9zDeH5i/SUL85mku9HqzTI/OCZ8EQ3aicbMW+eK5Nyu5w==",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.4",
@@ -39535,12 +39635,14 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -40142,7 +40244,8 @@
     "pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -41042,6 +41145,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -42129,6 +42233,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/starknet/-/starknet-3.9.0.tgz",
       "integrity": "sha512-/sn3WHFX7f+A3vVf3I+Kamg2KIW6494vpCcZWA09IQ5RZXrozjaBtYWT41SoKKWZ3b0Xg8WF//SOkRVCTZOZkQ==",
+      "dev": true,
       "requires": {
         "@ledgerhq/hw-app-eth": "^6.26.0",
         "@ledgerhq/hw-transport": "^6.24.1",
@@ -42149,6 +42254,7 @@
           "version": "0.23.0",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
           "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+          "dev": true,
           "requires": {
             "follow-redirects": "^1.14.4"
           }
@@ -42156,12 +42262,14 @@
         "bn.js": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
         },
         "ethereum-cryptography": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.2.5.tgz",
           "integrity": "sha512-aWvqiegXgSTwbuDE1DDnM7taLteLcHVHh5nMZnnD2dwlvH6w5bOxcdXW20oS+1aLDorDlrK1c82stB8jsLDN5Q==",
+          "dev": true,
           "requires": {
             "@noble/hashes": "^0.5.7",
             "@noble/secp256k1": "^1.4.0",
@@ -42277,7 +42385,8 @@
     "superstruct": {
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.4.tgz",
-      "integrity": "sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw=="
+      "integrity": "sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw==",
+      "dev": true
     },
     "supports-color": {
       "version": "7.2.0",
@@ -42830,7 +42939,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsort": {
       "version": "0.0.1",
@@ -43031,7 +43141,8 @@
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@imtbl/starknet",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "Immutable X StarkNet contracts",
   "scripts": {
-    "compile": "npx hardhat compile && npx hardhat starknet-compile ./immutablex && npx hardhat starknet-compile ./tests",
+    "compile": "npx hardhat compile && npx hardhat starknet-compile ./immutablex",
     "compile:cairo": "npx hardhat starknet-compile",
     "test": "npx hardhat test",
     "clean": "rm -r starknet-artifacts"

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,0 +1,22 @@
+["protostar.config"]
+protostar_version = "0.2.3"
+
+["protostar.project"]
+libs_path = "lib"
+
+["protostar.shared_command_configs"]
+cairo_path = ["./lib/cairo_contracts/src", "./lib/cairo_lib/src"]
+
+["protostar.contracts"]
+erc20_mintable_capped = [
+    "./immutablex/starknet/token/erc20/presets/ERC20_Mintable_Capped.cairo",
+]
+erc721_full = [
+    "./immutablex/starknet/token/erc721/presets/ERC721_Full.cairo",
+]
+payment_splitter = [
+    "./immutablex/starknet/finance/PaymentSplitter.cairo",
+]
+bridge = [
+    "./immutablex/starknet/bridge/StandardERC721Bridge.cairo",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ multidict==6.0.2
 mypy-extensions==0.4.3
 netaddr==0.8.0
 numpy==1.21.5
-openzeppelin-cairo-contracts==0.1.0
+openzeppelin-cairo-contracts==0.2.0
 packaging==21.3
 parsimonious==0.8.1
 pipdeptree==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='immutablex-starknet',
-    version='0.2.0',
+    version='0.2.1',
     description='Immutable X StarkNet Contracts',
     url='https://github.com/immutable/imx-starknet',
     author='Immutable',

--- a/tests/functional/starknet/hardhat/AccessControl.test.ts
+++ b/tests/functional/starknet/hardhat/AccessControl.test.ts
@@ -1,0 +1,230 @@
+import { expect } from "chai";
+import { starknet } from "hardhat";
+import { shouldFail, tryCatch } from "../../../utils/starknetUtils";
+import { StarknetContract } from "hardhat/types/runtime";
+import { deployTestAccessControl } from "../../../utils/starknetDeploys";
+import { Account } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+
+describe("AccessControl Test Cases", function () {
+  this.timeout(300_000); // 5 min
+
+  let accessControl: StarknetContract;
+  let acc1: Account;
+  let acc2: Account;
+  let acc3: Account;
+
+  before(async function () {
+    acc1 = await starknet.deployAccount("OpenZeppelin");
+    acc2 = await starknet.deployAccount("OpenZeppelin");
+    acc3 = await starknet.deployAccount("OpenZeppelin");
+    console.log("Deployed acc1 address: ", acc1.starknetContract.address);
+    console.log("Deployed acc2 address: ", acc2.starknetContract.address);
+    console.log("Deployed acc3 address: ", acc3.starknetContract.address);
+    accessControl = await deployTestAccessControl(
+      BigInt(acc1.starknetContract.address)
+    );
+    console.log("Deployed AccessControl_mock address: ", accessControl.address);
+  });
+
+  it("Default admin should be a member of the default admin role", async function () {
+    await tryCatch(async () => {
+      let res = (
+        await accessControl.call("has_role", {
+          role: BigInt(0),
+          account: BigInt(acc1.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(1));
+      res = (await accessControl.call("get_role_admin", { role: BigInt(0) }))
+        .role_admin;
+      expect(res).to.deep.equal(BigInt(0));
+    });
+  });
+
+  it("Default admin can grant new roles to accounts", async function () {
+    await tryCatch(async () => {
+      await acc1.invoke(accessControl, "grant_role", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        account: BigInt(acc2.starknetContract.address),
+      });
+
+      await acc1.invoke(accessControl, "grant_role", {
+        role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+        account: BigInt(acc3.starknetContract.address),
+      });
+
+      let res = (
+        await accessControl.call("has_role", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account: BigInt(acc2.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(1));
+      res = (
+        await accessControl.call("get_role_admin", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        })
+      ).role_admin;
+      expect(res).to.deep.equal(BigInt(0));
+      res = (
+        await accessControl.call("has_role", {
+          role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+          account: BigInt(acc3.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(1));
+      res = (
+        await accessControl.call("get_role_admin", {
+          role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+        })
+      ).role_admin;
+      expect(res).to.deep.equal(BigInt(0));
+    });
+  });
+
+  it("Non role admin cannot grant new role to account", async function () {
+    await tryCatch(async () => {
+      await shouldFail(
+        acc2.invoke(accessControl, "grant_role", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account: BigInt(acc3.starknetContract.address),
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("Default admin can revoke role from account", async function () {
+    await tryCatch(async () => {
+      await acc1.invoke(accessControl, "revoke_role", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        account: BigInt(acc2.starknetContract.address),
+      });
+
+      let res = (
+        await accessControl.call("has_role", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account: BigInt(acc2.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(0));
+    });
+  });
+
+  it("Default admin can set role admin", async function () {
+    await tryCatch(async () => {
+      await acc1.invoke(accessControl, "set_role_admin", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        admin_role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+      });
+
+      let res = (
+        await accessControl.call("get_role_admin", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        })
+      ).role_admin;
+      expect(res).to.deep.equal(
+        starknet.shortStringToBigInt("MINTER_ADMIN_ROLE")
+      );
+    });
+  });
+
+  it("Non role admin cannot set role admin", async function () {
+    await tryCatch(async () => {
+      await shouldFail(
+        acc2.invoke(accessControl, "set_role_admin", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          admin_role: starknet.shortStringToBigInt("FAKE_MINTER_ADMIN_ROLE"),
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("Default admin cannot grant role for a role with a non-zero (defined) admin role", async function () {
+    await tryCatch(async () => {
+      await shouldFail(
+        acc1.invoke(accessControl, "grant_role", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account: BigInt(acc2.starknetContract.address),
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("Account with admin role can grant role to account", async function () {
+    await tryCatch(async () => {
+      await acc3.invoke(accessControl, "grant_role", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        account: BigInt(acc2.starknetContract.address),
+      });
+
+      let res = (
+        await accessControl.call("has_role", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account: BigInt(acc2.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(1));
+    });
+  });
+
+  it("Account with admin role can revoke roles for their managed role", async function () {
+    await tryCatch(async () => {
+      await acc3.invoke(accessControl, "revoke_role", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        account: BigInt(acc2.starknetContract.address),
+      });
+
+      let res = (
+        await accessControl.call("has_role", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account: BigInt(acc2.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(0));
+    });
+  });
+
+  it("Account with admin role cannot revoke roles for which it is not an admin", async function () {
+    await tryCatch(async () => {
+      await shouldFail(
+        acc3.invoke(accessControl, "revoke_role", {
+          role: starknet.shortStringToBigInt("DEFAULT_ADMIN_ROLE"),
+          account: BigInt(acc1.starknetContract.address),
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("Account cannot renounce role for another account", async function () {
+    await tryCatch(async () => {
+      await shouldFail(
+        acc1.invoke(accessControl, "renounce_role", {
+          role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+          account: BigInt(acc3.starknetContract.address),
+        }),
+        "AccessControl: can only renounce roles for self"
+      );
+    });
+  });
+
+  it("Role member can renounce role", async function () {
+    await tryCatch(async () => {
+      await acc3.invoke(accessControl, "renounce_role", {
+        role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+        account: BigInt(acc3.starknetContract.address),
+      });
+
+      let res = (
+        await accessControl.call("has_role", {
+          role: starknet.shortStringToBigInt("MINTER_ADMIN_ROLE"),
+          account: BigInt(acc3.starknetContract.address),
+        })
+      ).res;
+      expect(res).to.deep.equal(BigInt(0));
+    });
+  });
+});

--- a/tests/functional/starknet/hardhat/PaymentSplitter.test.ts
+++ b/tests/functional/starknet/hardhat/PaymentSplitter.test.ts
@@ -1,0 +1,317 @@
+import { expect } from "chai";
+import { starknet } from "hardhat";
+import { number, stark } from "starknet";
+import {
+  toUint256WithFelts,
+  tryCatch,
+  shouldFail,
+} from "../../../utils/starknetUtils";
+import { StarknetContract } from "hardhat/types/runtime";
+import { Account } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import { deployERC20 } from "../../../utils/starknetDeploys";
+
+describe("PaymentSplitter Test Cases", function () {
+  this.timeout(300_000); // 5 min
+
+  let splitter: StarknetContract;
+  let ERC20: StarknetContract;
+  let acc1: Account;
+  let acc2: Account;
+
+  before(async function () {
+    acc1 = await starknet.deployAccount("OpenZeppelin");
+    acc2 = await starknet.deployAccount("OpenZeppelin");
+    console.log("Deployed acc1 address: ", acc1.starknetContract.address);
+    console.log("Deployed acc2 address: ", acc2.starknetContract.address);
+    ERC20 = await deployERC20(
+      BigInt(acc1.starknetContract.address),
+      "ERC20_Mintable_Capped"
+    );
+  });
+
+  describe("Deploy", function () {
+    it("Deploy with valid inputs", async function () {
+      await tryCatch(async () => {
+        // convert inputs to appropriate types
+        const payees = [
+          BigInt(acc1.starknetContract.address),
+          BigInt(acc2.starknetContract.address),
+        ];
+        const shares = [BigInt(150), BigInt(50)];
+
+        // Deploy the contract
+        const splitterContractFactory = await starknet.getContractFactory(
+          "PaymentSplitter"
+        );
+        // This lets us reuse the same contract over multiple tests - not good practice but redues test times
+        splitter = await splitterContractFactory.deploy({ payees, shares });
+
+        // Call getter functions
+        const ts = (await splitter.call("totalShares")).total_shares;
+        const p1 = (await splitter.call("payee", { index: BigInt(0) })).payee;
+        const p2 = (await splitter.call("payee", { index: BigInt(1) })).payee;
+        const pc = (await splitter.call("payeeCount")).payee_count;
+        const s1 = (
+          await splitter.call("shares", {
+            payee: BigInt(acc1.starknetContract.address),
+          })
+        ).shares;
+        const s2 = (
+          await splitter.call("shares", {
+            payee: BigInt(acc2.starknetContract.address),
+          })
+        ).shares;
+
+        // Expect to match inputs
+        expect(p1).to.deep.equal(payees[1]);
+        expect(p2).to.deep.equal(payees[0]);
+        expect(pc).to.deep.equal(BigInt(2));
+        expect(ts).to.deep.equal(BigInt(200));
+        expect(s1).to.deep.equal(BigInt(150));
+        expect(s2).to.deep.equal(BigInt(50));
+
+        // Optional decoding to original types
+        console.log(
+          `Deployed PaymentSplitter contract address ${splitter.address}:`
+        );
+        console.log("Total Payees: ", pc.toString());
+        console.log("Payee1: ", number.toHex(number.toBN(p1)));
+        console.log("Payee2: ", number.toHex(number.toBN(p2)));
+        console.log("Total Shares: ", ts.toString());
+        console.log("Payee1 shares: ", s1.toString());
+        console.log("Payee2 shares: ", s2.toString());
+      });
+    });
+
+    it("Should not deploy with different length payees and shares arrays", async function () {
+      await tryCatch(async () => {
+        const payees = [
+          BigInt(acc1.starknetContract.address),
+          BigInt(acc2.starknetContract.address),
+        ];
+        const shares = [BigInt(150), BigInt(50), BigInt(20)];
+
+        const splitterContractFactory = await starknet.getContractFactory(
+          "PaymentSplitter"
+        );
+        await shouldFail(
+          splitterContractFactory.deploy({ payees, shares }),
+          "PaymentSplitter: payees and shares not of equal length"
+        );
+      });
+    });
+
+    it("Should not deploy with 0 shares for a payee", async function () {
+      await tryCatch(async () => {
+        const payees = [
+          BigInt(acc1.starknetContract.address),
+          BigInt(acc2.starknetContract.address),
+        ];
+        const shares = [BigInt(150), BigInt(0)];
+
+        const splitterContractFactory = await starknet.getContractFactory(
+          "PaymentSplitter"
+        );
+        await shouldFail(
+          splitterContractFactory.deploy({ payees, shares }),
+          "PaymentSplitter: shares must be greater than zero"
+        );
+      });
+    });
+
+    it("Should not deploy with payee that appears twice in payees array", async function () {
+      await tryCatch(async () => {
+        const payees = [
+          BigInt(acc1.starknetContract.address),
+          BigInt(acc2.starknetContract.address),
+          BigInt(acc1.starknetContract.address),
+        ];
+        const shares = [BigInt(150), BigInt(50), BigInt(20)];
+
+        const splitterContractFactory = await starknet.getContractFactory(
+          "PaymentSplitter"
+        );
+        await shouldFail(
+          splitterContractFactory.deploy({ payees, shares }),
+          "PaymentSplitter: payee already has shares"
+        );
+      });
+    });
+
+    it("Should not deploy with no payees", async function () {
+      await tryCatch(async () => {
+        const payees: any = [];
+        const shares: any = [];
+
+        const splitterContractFactory = await starknet.getContractFactory(
+          "PaymentSplitter"
+        );
+        await shouldFail(
+          splitterContractFactory.deploy({ payees, shares }),
+          "PaymentSplitter: number of payees must be greater than zero"
+        );
+      });
+    });
+  });
+
+  describe("Payment", function () {
+    it("Payer can transfer ERC20 tokens to PaymentSplitter contract", async function () {
+      await tryCatch(async () => {
+        const amount = toUint256WithFelts(100);
+        await acc1.invoke(ERC20, "mint", {
+          to: BigInt(acc1.starknetContract.address),
+          amount: toUint256WithFelts(300),
+        });
+        await acc1.invoke(ERC20, "transfer", {
+          recipient: BigInt(splitter.address),
+          amount,
+        });
+
+        let balanceFromTokenContract = (
+          await ERC20.call("balanceOf", { account: BigInt(splitter.address) })
+        ).balance;
+        expect(balanceFromTokenContract).to.deep.equal(amount);
+        let balanceFromSplitterContract = (
+          await splitter.call("balance", { token: BigInt(ERC20.address) })
+        ).balance;
+        expect(balanceFromSplitterContract).to.deep.equal(amount);
+      });
+    });
+
+    it("Payee can check their pending payment balance in the PaymentSplitter contract", async function () {
+      await tryCatch(async () => {
+        let payment1 = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc1.starknetContract.address),
+          })
+        ).payment;
+        expect(payment1).to.deep.equal(toUint256WithFelts(75));
+        let payment2 = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc2.starknetContract.address),
+          })
+        ).payment;
+        expect(payment2).to.deep.equal(toUint256WithFelts(25));
+      });
+    });
+
+    it("pendingPayment should fail if the ERC20 contract does not exist", async function () {
+      const randomAddress = stark.randomAddress();
+      await shouldFail(
+        splitter.call("pendingPayment", {
+          token: BigInt(randomAddress),
+          payee: BigInt(acc1.starknetContract.address),
+        }),
+        `PaymentSplitter: Failed to call balanceOf on token contract`
+      );
+    });
+  });
+
+  describe("Release", function () {
+    it("Payee with no shares cannot release any funds", async function () {
+      await shouldFail(
+        // arbitrary payee address with no shares
+        acc1.invoke(splitter, "release", {
+          token: BigInt(ERC20.address),
+          payee: BigInt(stark.randomAddress()),
+        }),
+        "PaymentSplitter: payee has no shares"
+      );
+    });
+
+    it("Payee can release their pending payment", async function () {
+      await tryCatch(async () => {
+        await acc1.invoke(splitter, "release", {
+          token: BigInt(ERC20.address),
+          payee: BigInt(acc1.starknetContract.address),
+        });
+
+        let pendingPayment = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc1.starknetContract.address),
+          })
+        ).payment;
+        let released = (
+          await splitter.call("released", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc1.starknetContract.address),
+          })
+        ).released;
+        let totalReleased = (
+          await splitter.call("totalReleased", { token: BigInt(ERC20.address) })
+        ).total_released;
+        let payeeBalance = (
+          await ERC20.call("balanceOf", {
+            account: BigInt(acc1.starknetContract.address),
+          })
+        ).balance;
+
+        expect(pendingPayment).to.deep.equal(toUint256WithFelts(0));
+        expect(released).to.deep.equal(toUint256WithFelts(75));
+        expect(totalReleased).to.deep.equal(toUint256WithFelts(75));
+        expect(payeeBalance).to.deep.equal(toUint256WithFelts(75 + 200)); // 75 released + 200 not yet transferred
+      });
+    });
+
+    it("Payee with no pending payment for a given ERC20 cannot release any funds", async function () {
+      await shouldFail(
+        acc1.invoke(splitter, "release", {
+          token: BigInt(ERC20.address),
+          payee: BigInt(acc1.starknetContract.address),
+        }),
+        "PaymentSplitter: payee is not due any payment"
+      );
+    });
+
+    it("Payee pending payment is calculated correctly after receiving more funds", async function () {
+      await tryCatch(async () => {
+        await acc1.invoke(ERC20, "transfer", {
+          recipient: BigInt(splitter.address),
+          amount: toUint256WithFelts(100),
+        });
+
+        let payment1 = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc1.starknetContract.address),
+          })
+        ).payment;
+        expect(payment1).to.deep.equal(toUint256WithFelts(0 + 75)); // 0 after releasing previous payment + 75 from new payment
+        let payment2 = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc2.starknetContract.address),
+          })
+        ).payment;
+        expect(payment2).to.deep.equal(toUint256WithFelts(25 + 25)); // 25 from previous payment unreleased + 25 from new payment
+      });
+    });
+
+    it("Pending payment correctly rounds down with fee splits that are not exactly divisible", async function () {
+      await tryCatch(async () => {
+        await acc1.invoke(ERC20, "transfer", {
+          recipient: BigInt(splitter.address),
+          amount: toUint256WithFelts(15),
+        });
+
+        let payment1 = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc1.starknetContract.address),
+          })
+        ).payment;
+        expect(payment1).to.deep.equal(toUint256WithFelts(75 + 11)); // 75 from previous test + [(15 * (150/200 shares)) = 11.25 = 11 rounded down]
+        let payment2 = (
+          await splitter.call("pendingPayment", {
+            token: BigInt(ERC20.address),
+            payee: BigInt(acc2.starknetContract.address),
+          })
+        ).payment;
+        expect(payment2).to.deep.equal(toUint256WithFelts(50 + 3)); // 50 from previous test + [(15 * (50/200 shares)) = 3.75 = 3 rounded down]
+      });
+    });
+  });
+});

--- a/tests/functional/starknet/hardhat/erc20/ERC20_Mintable_Capped.test.ts
+++ b/tests/functional/starknet/hardhat/erc20/ERC20_Mintable_Capped.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "chai";
+import { starknet } from "hardhat";
+import {
+  toUint256WithFelts,
+  tryCatch,
+  shouldFail,
+} from "../../../../utils/starknetUtils";
+import { StarknetContract } from "hardhat/types/runtime";
+import { Account } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import { deployERC20 } from "../../../../utils/starknetDeploys";
+
+describe("ERC20_Mintable_Capped test cases", function () {
+  this.timeout(300_000); // 5 min
+
+  // This lets us reuse the same contract over multiple tests - not good practice but redues test times slightly
+  let contract: StarknetContract;
+  let acc1: Account;
+  let acc2: Account;
+
+  before(async function () {
+    acc1 = await starknet.deployAccount("OpenZeppelin");
+    acc2 = await starknet.deployAccount("OpenZeppelin");
+    console.log("Deployed acc1 address: ", acc1.starknetContract.address);
+    console.log("Deployed acc2 address: ", acc2.starknetContract.address);
+    contract = await deployERC20(
+      BigInt(acc1.starknetContract.address),
+      "ERC20_Mintable_Capped"
+    );
+  });
+
+  describe("Mintable", function () {
+    it("As a contract owner, I should be able to mint a given amount to any user", async function () {
+      await tryCatch(async () => {
+        const toWallet1 = BigInt(acc1.starknetContract.address);
+        const toWallet2 = BigInt(acc2.starknetContract.address);
+        const amount = toUint256WithFelts("100");
+        await acc1.invoke(contract, "mint", { to: toWallet1, amount: amount });
+        await acc1.invoke(contract, "mint", { to: toWallet2, amount: amount });
+
+        let balance = (await contract.call("balanceOf", { account: toWallet1 }))
+          .balance;
+        expect(balance).to.deep.equal(amount);
+        balance = (await contract.call("balanceOf", { account: toWallet2 }))
+          .balance;
+        expect(balance).to.deep.equal(amount);
+      });
+    });
+
+    it("As a non-contract-owner, I should be not able to mint tokens", async function () {
+      await tryCatch(async () => {
+        const toWallet = BigInt(acc2.starknetContract.address);
+        const amount = toUint256WithFelts("100");
+        await shouldFail(
+          acc2.invoke(contract, "mint", { to: toWallet, amount: amount }),
+          "Ownable: caller is not the owner"
+        );
+      });
+    });
+  });
+
+  describe("Capped", function () {
+    it("As a contract owner, minting should not be able to exceed the maximum supply cap", async function () {
+      await tryCatch(async () => {
+        const toWallet = BigInt(acc1.starknetContract.address);
+        const amount = toUint256WithFelts("1000001");
+        await shouldFail(
+          acc1.invoke(contract, "mint", { to: toWallet, amount: amount }),
+          "Capped: cap exceeded"
+        );
+      });
+    });
+  });
+
+  describe("Ownable", function () {
+    it("As a non-contract owner, I should not be able to change contract ownership", async function () {
+      await tryCatch(async () => {
+        const newOwner = BigInt(acc2.starknetContract.address);
+        await shouldFail(
+          acc2.invoke(contract, "transferOwnership", { new_owner: newOwner }),
+          "Ownable: caller is not the owner"
+        );
+      });
+    });
+
+    it("As a contract owner, I should be able to transfer contract ownership to another user", async function () {
+      await tryCatch(async () => {
+        const newOwner = BigInt(acc2.starknetContract.address);
+        await acc1.invoke(contract, "transferOwnership", {
+          new_owner: newOwner,
+        });
+
+        const owner = (await contract.call("owner")).owner;
+        expect(owner).to.deep.equal(newOwner);
+      });
+    });
+  });
+});

--- a/tests/functional/starknet/hardhat/erc721/Bridgeable.test.ts
+++ b/tests/functional/starknet/hardhat/erc721/Bridgeable.test.ts
@@ -1,0 +1,176 @@
+import { expect } from "chai";
+import { starknet, config } from "hardhat";
+import {
+  toUint256WithFelts,
+  tryCatch,
+  shouldFail,
+} from "../../../../utils/starknetUtils";
+import { StarknetContract } from "hardhat/types/runtime";
+import { Account } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import { deployERC721 } from "../../../../utils/starknetDeploys";
+
+describe("Bridgeable Test Cases", function () {
+  console.log(`Using network ${config.starknet.network}`);
+  this.timeout(300_000); // 5 min
+
+  let contract: StarknetContract;
+  let acc1: Account;
+  let mockBridge: Account;
+
+  before(async function () {
+    acc1 = await starknet.deployAccount("OpenZeppelin");
+    mockBridge = await starknet.deployAccount("OpenZeppelin");
+    console.log("Deployed acc1 address: ", acc1.starknetContract.address);
+    console.log(
+      "Deployed mockBridge address: ",
+      mockBridge.starknetContract.address
+    );
+    contract = await deployERC721(
+      BigInt(acc1.starknetContract.address),
+      "ERC721_Full"
+    );
+  });
+
+  /*
+		ContractOwner: The 'owner' of the contract, defined as an account with the default admin role.
+		NFTOwner: The 'owner' of a particular NFT.
+	*/
+  it("ContractOwner can add an account to the minter and burner role", async function () {
+    await tryCatch(async () => {
+      const account = BigInt(mockBridge.starknetContract.address);
+
+      expect(
+        (
+          await contract.call("hasRole", {
+            role: starknet.shortStringToBigInt("MINTER_ROLE"),
+            account,
+          })
+        ).res
+      ).to.equal(BigInt(0));
+      expect(
+        (
+          await contract.call("hasRole", {
+            role: starknet.shortStringToBigInt("BURNER_ROLE"),
+            account,
+          })
+        ).res
+      ).to.equal(BigInt(0));
+
+      await acc1.invoke(contract, "grantRole", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        account,
+      });
+      await acc1.invoke(contract, "grantRole", {
+        role: starknet.shortStringToBigInt("BURNER_ROLE"),
+        account,
+      });
+
+      expect(
+        (
+          await contract.call("hasRole", {
+            role: starknet.shortStringToBigInt("MINTER_ROLE"),
+            account,
+          })
+        ).res
+      ).to.equal(BigInt(1));
+      expect(
+        (
+          await contract.call("hasRole", {
+            role: starknet.shortStringToBigInt("BURNER_ROLE"),
+            account,
+          })
+        ).res
+      ).to.equal(BigInt(1));
+    });
+  });
+
+  it("Non-ContractOwner cannot grant roles to accounts", async function () {
+    await tryCatch(async () => {
+      const account = BigInt(acc1.starknetContract.address);
+      await shouldFail(
+        mockBridge.invoke(contract, "grantRole", {
+          role: starknet.shortStringToBigInt("MINTER_ROLE"),
+          account,
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("Minter role member can call permissionedMint", async function () {
+    await tryCatch(async () => {
+      expect(
+        (
+          await contract.call("hasRole", {
+            role: starknet.shortStringToBigInt("MINTER_ROLE"),
+            account: BigInt(mockBridge.starknetContract.address),
+          })
+        ).res
+      ).to.equal(BigInt(1));
+
+      await mockBridge.invoke(contract, "permissionedMint", {
+        account: BigInt(acc1.starknetContract.address),
+        tokenId: toUint256WithFelts(1),
+      });
+
+      expect(
+        (await contract.call("ownerOf", { tokenId: toUint256WithFelts(1) }))
+          .owner
+      ).to.equal(BigInt(acc1.starknetContract.address));
+    });
+  });
+
+  it("Non minter role member cannot call permissionedMint", async function () {
+    await tryCatch(async () => {
+      await shouldFail(
+        acc1.invoke(contract, "permissionedMint", {
+          account: BigInt(acc1.starknetContract.address),
+          tokenId: toUint256WithFelts(2),
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("Burner role member can call permissionedBurn", async function () {
+    await tryCatch(async () => {
+      await mockBridge.invoke(contract, "permissionedBurn", {
+        tokenId: toUint256WithFelts(1),
+      });
+
+      expect(
+        (
+          await contract.call("balanceOf", {
+            owner: BigInt(acc1.starknetContract.address),
+          })
+        ).balance
+      ).to.deep.equal(toUint256WithFelts(0));
+    });
+  });
+
+  it("ContractOwner can revoke role for an account", async function () {
+    await tryCatch(async () => {
+      const account = BigInt(mockBridge.starknetContract.address);
+      await acc1.invoke(contract, "revokeRole", {
+        role: starknet.shortStringToBigInt("MINTER_ROLE"),
+        account,
+      });
+
+      expect(
+        (
+          await contract.call("hasRole", {
+            role: starknet.shortStringToBigInt("MINTER_ROLE"),
+            account,
+          })
+        ).res
+      ).to.equal(BigInt(0));
+      await shouldFail(
+        mockBridge.invoke(contract, "permissionedMint", {
+          account: BigInt(acc1.starknetContract.address),
+          tokenId: toUint256WithFelts(2),
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+});

--- a/tests/functional/starknet/hardhat/erc721/ERC721.test.ts
+++ b/tests/functional/starknet/hardhat/erc721/ERC721.test.ts
@@ -1,0 +1,462 @@
+import { expect } from "chai";
+import { starknet, config } from "hardhat";
+import {
+  toUint256WithFelts,
+  tryCatch,
+  shouldFail,
+  fromUint256WithFelts,
+  strToFeltArr,
+  feltArrToStr,
+} from "../../../../utils/starknetUtils";
+import { StarknetContract } from "hardhat/types/runtime";
+import { Account } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import { deployERC721 } from "../../../../utils/starknetDeploys";
+
+// TODO: This test cases should be modularised once devnet is working
+describe("ERC721 Test Cases", function () {
+  console.log(`Using network ${config.starknet.network}`);
+  this.timeout(300_000); // 5 min
+
+  let contract: StarknetContract;
+  let acc1: Account;
+  let acc2: Account;
+  let acc3: Account;
+
+  before(async function () {
+    acc1 = await starknet.deployAccount("OpenZeppelin");
+    acc2 = await starknet.deployAccount("OpenZeppelin");
+    acc3 = await starknet.deployAccount("OpenZeppelin");
+    console.log("Deployed acc1 address: ", acc1.starknetContract.address);
+    console.log("Deployed acc2 address: ", acc2.starknetContract.address);
+    console.log("Deployed acc3 address: ", acc3.starknetContract.address);
+    contract = await deployERC721(
+      BigInt(acc1.starknetContract.address),
+      "ERC721_Full"
+    );
+
+    // Grant contract owner minter role
+    await acc1.invoke(contract, "grantRole", {
+      role: starknet.shortStringToBigInt("MINTER_ROLE"),
+      account: BigInt(acc1.starknetContract.address),
+    });
+  });
+
+  /*
+		ContractOwner: The 'owner' of the contract, defined as an account with the default admin role.
+		NFTOwner: The 'owner' of a particular NFT.
+	*/
+  it("ContractOwner can mint NFTs to a different address", async function () {
+    await tryCatch(async () => {
+      const toWallet = BigInt(acc2.starknetContract.address);
+      const num0 = toUint256WithFelts("0");
+      const num1 = toUint256WithFelts("1");
+      const num2 = toUint256WithFelts("2");
+      const num3 = toUint256WithFelts("3");
+      const num4 = toUint256WithFelts("4");
+      const num5 = toUint256WithFelts("5");
+
+      // acc1 (owner) attempt to mint to acc2 an NFT with tokenId 0 and expects balance to be 1
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: num0,
+      });
+      const balance1 = (await contract.call("balanceOf", { owner: toWallet }))
+        .balance;
+      expect(balance1).to.deep.equal(num1);
+
+      // acc1 (owner) attempt to mint to acc2 an NFT with tokenId 1 and expects balance to be 2
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: num1,
+      });
+      const balance2 = (await contract.call("balanceOf", { owner: toWallet }))
+        .balance;
+      expect(balance2).to.deep.equal(num2);
+
+      // acc1 (owner) attempt to mint to acc2 an NFT with tokenId 2 and expects balance to be 3
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: num2,
+      });
+      const balance3 = (await contract.call("balanceOf", { owner: toWallet }))
+        .balance;
+      expect(balance3).to.deep.equal(num3);
+
+      // acc1 (owner) attempt to mint to acc2 an NFT with tokenId 3 and expects balance to be 4
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: num3,
+      });
+      const balance4 = (await contract.call("balanceOf", { owner: toWallet }))
+        .balance;
+      expect(balance4).to.deep.equal(num4);
+
+      // acc1 (owner) attempt to mint to acc2 an NFT with tokenId 4 and expects balance to be 5
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: num4,
+      });
+      const balance5 = (await contract.call("balanceOf", { owner: toWallet }))
+        .balance;
+      expect(balance5).to.deep.equal(num5);
+    });
+  });
+
+  it("Attempt to get tokenURI for a minted token without a set tokenURI or baseURI should return 0", async function () {
+    await tryCatch(async () => {
+      const tokenId = toUint256WithFelts("0");
+      const resultURIArr = (await contract.call("tokenURI", { tokenId }))
+        .tokenURI;
+      expect(resultURIArr).to.deep.equal([]);
+    });
+  });
+
+  it("ContractOwner can set reasonable size baseURI", async function () {
+    await tryCatch(async () => {
+      const url =
+        "https://ipfs.io/ipfs/this-is-a-reasonable-sized-base-uri-set-by-the-owner/";
+
+      // url must be converted to a felt array as that is the functions input type
+      const baseTokenURI = strToFeltArr(url);
+      await acc1.invoke(contract, "setBaseURI", {
+        base_token_uri: baseTokenURI,
+      });
+      const tokenId = toUint256WithFelts("0");
+      const resultURIArr = (await contract.call("tokenURI", { tokenId }))
+        .tokenURI;
+      const resultURI = feltArrToStr(resultURIArr);
+
+      // The decoded return value of tokenURI should be equal to the baseURI ++ tokenId
+      expect(resultURI).to.deep.equal(`${url}0`);
+    });
+  });
+
+  it("ContractOwner can set tokenURI to override baseURI for a particular NFT ", async function () {
+    await tryCatch(async () => {
+      const url = "https://ipfs.io/ipfs/this-NFT-has-tokenId-set";
+
+      // url must be converted to a felt array as that is the functions input type
+      const tokenURI = strToFeltArr(url);
+      const tokenId = toUint256WithFelts("1");
+
+      // We setTokenURI for tokenId 1 as the owner (acc1) of the contract
+      await acc1.invoke(contract, "setTokenURI", { tokenId, tokenURI });
+      const resultURIArr = (await contract.call("tokenURI", { tokenId }))
+        .tokenURI;
+      const resultURI = feltArrToStr(resultURIArr);
+
+      // The decoded return value of tokenURI for tokenId 1 should be equal to the tokenURI and NOT the baseURI
+      expect(resultURI).to.deep.equal(`${url}`);
+
+      // We ensure that tokenId, which did not have setTokenURI called still used baseURI
+      const tokenId2 = toUint256WithFelts("2");
+      const result2URIArr = (
+        await contract.call("tokenURI", { tokenId: tokenId2 })
+      ).tokenURI;
+      const result2URI = feltArrToStr(result2URIArr);
+      const baseUrl =
+        "https://ipfs.io/ipfs/this-is-a-reasonable-sized-base-uri-set-by-the-owner/";
+
+      // The decoded return value of tokenURI for tokenId 2 should be equal to baseURI ++ tokenId
+      expect(result2URI).to.deep.equal(`${baseUrl}2`);
+    });
+  });
+
+  it("ContractOwner can reset tokenURI, and it should revert to using the baseURI", async function () {
+    await tryCatch(async () => {
+      // url must be converted to a felt array as that is the functions input type
+      const tokenId = toUint256WithFelts("1");
+
+      // We setTokenURI for tokenId 1 as the owner (acc1) of the contract to empty
+      await acc1.invoke(contract, "resetTokenURI", { tokenId });
+      const resultURIArr = (await contract.call("tokenURI", { tokenId }))
+        .tokenURI;
+      const resultURI = feltArrToStr(resultURIArr);
+
+      // The decoded return value of tokenURI for tokenId 1 should be equal to the baseURI ++ tokenId
+      const baseUrl =
+        "https://ipfs.io/ipfs/this-is-a-reasonable-sized-base-uri-set-by-the-owner/";
+      expect(resultURI).to.deep.equal(`${baseUrl}1`);
+    });
+  });
+
+  it("ContractOwner can set ASCII character set in baseURI", async function () {
+    await tryCatch(async () => {
+      const url = 'https://() !"[~^.Za1234567890AbcDseksicmab';
+      const baseTokenURI = strToFeltArr(url);
+      await acc1.invoke(contract, "setBaseURI", {
+        base_token_uri: baseTokenURI,
+      });
+      const tokenId = toUint256WithFelts("0");
+      const resultURIArr = (await contract.call("tokenURI", { tokenId }))
+        .tokenURI;
+      const resultURI = feltArrToStr(resultURIArr);
+      expect(resultURI).to.deep.equal(`${url}0`);
+    });
+  });
+
+  it("ContractOwner can set NOT ASCII character set in TokenURI, but will fail to decode", async function () {
+    await tryCatch(async () => {
+      const url = "भारत网络";
+      const baseTokenURI = strToFeltArr(url);
+      await acc1.invoke(contract, "setBaseURI", {
+        base_token_uri: baseTokenURI,
+      });
+      const tokenId = toUint256WithFelts("0");
+      const resultURIArr = (await contract.call("tokenURI", { tokenId }))
+        .tokenURI;
+      const resultURI = feltArrToStr(resultURIArr);
+      expect(resultURI).to.not.deep.equal(`${url}0`);
+    });
+  });
+
+  it("ContractOwner can set reasonable size ContractURI", async function () {
+    await tryCatch(async () => {
+      const url =
+        "https://ipfs.io/ipfs/the-owner-is-trying-set-a-reasonable-sized-contract-uri/";
+      const contractURI = strToFeltArr(url);
+
+      // We use acc1 to invoke setContractURI which should pass as they are the contract owners
+      await acc1.invoke(contract, "setContractURI", {
+        contract_uri: contractURI,
+      });
+      const resultURIArr = (await contract.call("contractURI")).contract_uri;
+      const resultURI = feltArrToStr(resultURIArr);
+
+      // The contractURI, when decode, should be equal to the input url
+      expect(resultURI).to.deep.equal(`${url}`);
+    });
+  });
+
+  it("NOT_ContractOwner can NOT set ContractURI", async function () {
+    await tryCatch(async () => {
+      const url =
+        "https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu/";
+      const contractURI = strToFeltArr(url);
+
+      // We use acc2 to invoke setContractURI, which should fail as they are not the owner of the contract
+      await shouldFail(
+        acc2.invoke(contract, "setContractURI", { contract_uri: contractURI }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("NOT_ContractOwner can NOT mint an NFT", async function () {
+    await tryCatch(async () => {
+      const toWallet = BigInt(acc2.starknetContract.address);
+      const tokenIdUint256 = toUint256WithFelts("20");
+
+      // We use acc2 to invoke mint which does not have permission to mint, hence should fail
+      await shouldFail(
+        acc2.invoke(contract, "permissionedMint", {
+          account: toWallet,
+          tokenId: tokenIdUint256,
+        }),
+        `AccessControl: account is missing role`
+      );
+    });
+  });
+
+  it("NFTOwner can `transferFrom` their NFT", async function () {
+    await tryCatch(async () => {
+      const fromAddress = BigInt(acc2.starknetContract.address);
+      const toAddress = BigInt(acc1.starknetContract.address);
+      // transfer tokenId 1
+      const tokenIdUint256 = toUint256WithFelts("1");
+
+      // expectedBalance of acc2 after transfer is balance-1
+      const originalBalanceFrom = (
+        await contract.call("balanceOf", { owner: fromAddress })
+      ).balance;
+      const expectedBalanceFrom = (
+        parseInt(fromUint256WithFelts(originalBalanceFrom).toString()) - 1
+      ).toString();
+
+      // expectedBalance of acc1 after transfer is balance+1
+      const originalBalanceTo = (
+        await contract.call("balanceOf", { owner: toAddress })
+      ).balance;
+      const expectedBalanceTo = (
+        parseInt(fromUint256WithFelts(originalBalanceTo).toString()) + 1
+      ).toString();
+
+      // invoke transferFrom as the owner of the NFT (acc2)
+      await acc2.invoke(contract, "transferFrom", {
+        from_: fromAddress,
+        to: toAddress,
+        tokenId: tokenIdUint256,
+      });
+
+      // ensure balance of acc2 is as expected
+      const balanceFrom = (
+        await contract.call("balanceOf", { owner: fromAddress })
+      ).balance;
+      expect(balanceFrom).to.deep.equal(
+        toUint256WithFelts(expectedBalanceFrom)
+      );
+
+      // ensure balance of acc1 is as expected
+      const balanceTo = (await contract.call("balanceOf", { owner: toAddress }))
+        .balance;
+      expect(balanceTo).to.deep.equal(toUint256WithFelts(expectedBalanceTo));
+    });
+  });
+
+  it("NFTOwner can `approve` someone else then they can transfer their NFT", async function () {
+    await tryCatch(async () => {
+      const fromAddress = BigInt(acc2.starknetContract.address);
+      const toAddress = BigInt(acc1.starknetContract.address);
+
+      // expected balance of acc2 after transfer should be balance-1
+      const originalBalanceFrom = (
+        await contract.call("balanceOf", { owner: fromAddress })
+      ).balance;
+      const expectedBalanceFrom = (
+        parseInt(fromUint256WithFelts(originalBalanceFrom).toString()) - 1
+      ).toString();
+
+      // expected balance of acc1 after transfer should be balance+1
+      const originalBalanceTo = (
+        await contract.call("balanceOf", { owner: toAddress })
+      ).balance;
+      const expectedBalanceTo = (
+        parseInt(fromUint256WithFelts(originalBalanceTo).toString()) + 1
+      ).toString();
+
+      // use tokenId 2
+      const tokenIdUint256 = toUint256WithFelts("2");
+
+      // approve acc1 as acc2 for tokenId
+      await acc2.invoke(contract, "approve", {
+        to: toAddress,
+        tokenId: tokenIdUint256,
+      });
+
+      // get approved for token should be acc1
+      const approvedForToken = (
+        await contract.call("getApproved", { tokenId: tokenIdUint256 })
+      ).approved;
+      expect(approvedForToken).to.deep.equal(toAddress);
+
+      // invoke transfer as acc1 who does not own the NFT but is approved
+      await acc1.invoke(contract, "transferFrom", {
+        from_: fromAddress,
+        to: toAddress,
+        tokenId: tokenIdUint256,
+      });
+
+      // ensure balance of acc2 is as expected
+      const balanceFrom = (
+        await contract.call("balanceOf", { owner: fromAddress })
+      ).balance;
+      expect(balanceFrom).to.deep.equal(
+        toUint256WithFelts(expectedBalanceFrom)
+      );
+      // ensure balance of acc1 is as expected
+      const balanceTo = (await contract.call("balanceOf", { owner: toAddress }))
+        .balance;
+      expect(balanceTo).to.deep.equal(toUint256WithFelts(expectedBalanceTo));
+    });
+  });
+
+  it("NFTOwner can `setApprovalForAll` and can also revoke approval", async function () {
+    await tryCatch(async () => {
+      const fromAddress = BigInt(acc2.starknetContract.address);
+      const toAddress = BigInt(acc1.starknetContract.address);
+
+      // expected balance of acc2 after transfer should be balance-2
+      const originalBalanceFrom = (
+        await contract.call("balanceOf", { owner: fromAddress })
+      ).balance;
+      const expectedBalanceFrom = (
+        parseInt(fromUint256WithFelts(originalBalanceFrom).toString()) - 2
+      ).toString();
+
+      // expected balance of acc1 after transfer should be balance+2
+      const originalBalanceTo = (
+        await contract.call("balanceOf", { owner: toAddress })
+      ).balance;
+      const expectedBalanceTo = (
+        parseInt(fromUint256WithFelts(originalBalanceTo).toString()) + 2
+      ).toString();
+
+      // use tokenId 3 & 4 & 5
+      const tokenId3 = toUint256WithFelts("3");
+      const tokenId4 = toUint256WithFelts("4");
+      const tokenId5 = toUint256WithFelts("4");
+
+      // approve acc1 as acc2 for all tokens
+      await acc2.invoke(contract, "setApprovalForAll", {
+        operator: toAddress,
+        approved: 1,
+      });
+
+      // get approved for token should be 1
+      const isApproved = (
+        await contract.call("isApprovedForAll", {
+          owner: fromAddress,
+          operator: toAddress,
+        })
+      ).isApproved;
+      expect(isApproved).to.deep.equal(1n);
+
+      // invoke transfer as acc1 who does not own the NFT3 but is approved for all
+      await acc1.invoke(contract, "transferFrom", {
+        from_: fromAddress,
+        to: toAddress,
+        tokenId: tokenId3,
+      });
+
+      // invoke transfer as acc1 who does not own the NFT4 but is approved for all
+      await acc1.invoke(contract, "transferFrom", {
+        from_: fromAddress,
+        to: toAddress,
+        tokenId: tokenId4,
+      });
+
+      // ensure balance of acc2 is as expected
+      const balanceFrom = (
+        await contract.call("balanceOf", { owner: fromAddress })
+      ).balance;
+      expect(balanceFrom).to.deep.equal(
+        toUint256WithFelts(expectedBalanceFrom)
+      );
+      // ensure balance of acc1 is as expected
+      const balanceTo = (await contract.call("balanceOf", { owner: toAddress }))
+        .balance;
+      expect(balanceTo).to.deep.equal(toUint256WithFelts(expectedBalanceTo));
+
+      // revoke approve of acc1 as acc2 for all tokens
+      await acc2.invoke(contract, "setApprovalForAll", {
+        operator: toAddress,
+        approved: 0,
+      });
+
+      const isApprovedAfterRevoke = (
+        await contract.call("isApprovedForAll", {
+          owner: fromAddress,
+          operator: toAddress,
+        })
+      ).isApproved;
+      expect(isApprovedAfterRevoke).to.deep.equal(0n);
+
+      // attempt to transfer NFT5 after getting approval revoked
+      await shouldFail(
+        acc1.invoke(contract, "transferFrom", {
+          from_: fromAddress,
+          to: toAddress,
+          tokenId: tokenId5,
+        }),
+        "ERC721: transfer from incorrect owner"
+      );
+    });
+  });
+});
+
+/*
+Questions:
+
+
+
+*/

--- a/tests/functional/starknet/hardhat/erc721/Royalties.test.ts
+++ b/tests/functional/starknet/hardhat/erc721/Royalties.test.ts
@@ -1,0 +1,260 @@
+import { expect } from "chai";
+import { BN } from "bn.js";
+import { starknet } from "hardhat";
+import {
+  toUint256WithFelts,
+  tryCatch,
+  shouldFail,
+} from "../../../../utils/starknetUtils";
+import { StarknetContract } from "hardhat/types/runtime";
+import { Account } from "@shardlabs/starknet-hardhat-plugin/dist/src/account";
+import { deployERC721 } from "../../../../utils/starknetDeploys";
+
+describe("Royalties Test Cases", function () {
+  this.timeout(300_000); // 5 min
+
+  let contract: StarknetContract;
+  let acc1: Account;
+  let acc2: Account;
+
+  before(async function () {
+    acc1 = await starknet.deployAccount("OpenZeppelin");
+    acc2 = await starknet.deployAccount("OpenZeppelin");
+    console.log("Deployed acc1 address: ", acc1.starknetContract.address);
+    console.log("Deployed acc2 address: ", acc2.starknetContract.address);
+    contract = await deployERC721(
+      BigInt(acc1.starknetContract.address),
+      "ERC721_Full"
+    );
+
+    // Grant contract owner minter roles
+    await acc1.invoke(contract, "grantRole", {
+      role: starknet.shortStringToBigInt("MINTER_ROLE"),
+      account: BigInt(acc1.starknetContract.address),
+    });
+  });
+
+  it("royaltyInfo should fail on query for an unminted token", async function () {
+    await tryCatch(async () => {
+      const salePrice = toUint256WithFelts(10);
+
+      await shouldFail(
+        contract.call("royaltyInfo", {
+          tokenId: toUint256WithFelts(1),
+          salePrice,
+        }),
+        "token ID does not exist"
+      );
+    });
+  });
+
+  it("ContractOwner cannot set a specific token royalty for unminted tokens", async function () {
+    await tryCatch(async () => {
+      const royaltyRecipient = BigInt(acc1.starknetContract.address);
+      const royaltyPercentage = 1000; // 10%
+
+      // should fail to set token royalty because token is not yet minted
+      await shouldFail(
+        acc1.invoke(contract, "setTokenRoyalty", {
+          tokenId: toUint256WithFelts(1),
+          receiver: royaltyRecipient,
+          feeBasisPoints: royaltyPercentage,
+        }),
+        `token ID does not exist`
+      );
+    });
+  });
+
+  it("Default royalty should be set upon initialization", async function () {
+    await tryCatch(async () => {
+      let defaultRoyalty = await contract.call("getDefaultRoyalty");
+
+      // default royalty = (acc1, 20%)
+      expect(defaultRoyalty.receiver).to.deep.equal(
+        BigInt(acc1.starknetContract.address)
+      );
+      expect(defaultRoyalty.feeBasisPoints).to.deep.equal(BigInt(2000));
+    });
+  });
+
+  it("ContractOwner can set a specific token royalty lower than the default royalty for a minted token", async function () {
+    await tryCatch(async () => {
+      // mint token id 1
+      const toWallet = BigInt(acc2.starknetContract.address);
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: toUint256WithFelts(1),
+      });
+      const percentage = 1200; // 12%
+      const salePrice = toUint256WithFelts(100);
+
+      await acc1.invoke(contract, "setTokenRoyalty", {
+        tokenId: toUint256WithFelts(1),
+        receiver: toWallet,
+        feeBasisPoints: percentage,
+      });
+
+      let royalty = await contract.call("royaltyInfo", {
+        tokenId: toUint256WithFelts(1),
+        salePrice,
+      });
+      // token royalty for id 1 = (acc2, 12%)
+      expect(royalty.receiver).to.deep.equal(toWallet);
+      expect(royalty.royaltyAmount).to.deep.equal(toUint256WithFelts(12)); // 12% of 100
+    });
+  });
+
+  it("ContractOwner can not set a specific token royalty lower than the default royalty but higher than the token royalty if already set", async function () {
+    await tryCatch(async () => {
+      const toWallet = BigInt(acc2.starknetContract.address);
+      const percentage = 1300; // 13%
+
+      await shouldFail(
+        acc1.invoke(contract, "setTokenRoyalty", {
+          tokenId: toUint256WithFelts(1),
+          receiver: toWallet,
+          feeBasisPoints: percentage,
+        }),
+        "ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points"
+      );
+    });
+  });
+
+  it("ContractOwner can not set a specific token royalty higher than the default royalty", async function () {
+    await tryCatch(async () => {
+      // mint token id 2
+      const toWallet = BigInt(acc2.starknetContract.address);
+      await acc1.invoke(contract, "permissionedMint", {
+        account: toWallet,
+        tokenId: toUint256WithFelts(2),
+      });
+      const percentage = 4750; // 47.5%
+
+      await shouldFail(
+        acc1.invoke(contract, "setTokenRoyalty", {
+          tokenId: toUint256WithFelts(2),
+          receiver: toWallet,
+          feeBasisPoints: percentage,
+        }),
+        "ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points"
+      );
+      // token royalty for id 2 = (0, 0)
+    });
+  });
+
+  it("ContractOwner can change royalty recipient without restrictions", async function () {
+    await tryCatch(async () => {
+      const recipient = BigInt(acc1.starknetContract.address);
+      const percentage = BigInt(1200); // 12%
+      const tokenId = toUint256WithFelts(1);
+      await acc1.invoke(contract, "setTokenRoyalty", {
+        tokenId,
+        receiver: recipient,
+        feeBasisPoints: percentage,
+      });
+
+      let royalty = await contract.call("royaltyInfo", {
+        tokenId: toUint256WithFelts(1),
+        salePrice: toUint256WithFelts(10000),
+      });
+      // token royalty for id 1 = (acc1, 12%)
+      expect(royalty.receiver).to.deep.equal(recipient);
+      expect(royalty.royaltyAmount).to.deep.equal(toUint256WithFelts(1200)); // 12%
+    });
+  });
+
+  // EIP-2981 states that implementers may choose round down or up to nearest integer
+  // This implementation (currently) always rounds down
+  it("royaltyAmount should round down to nearest integer", async function () {
+    await tryCatch(async () => {
+      const royaltyRecipient = BigInt(acc1.starknetContract.address);
+      const salePrice = toUint256WithFelts(10);
+
+      const royalty = await contract.call("royaltyInfo", {
+        tokenId: toUint256WithFelts(1),
+        salePrice,
+      });
+      expect(royalty.receiver).to.deep.equal(royaltyRecipient);
+      expect(royalty.royaltyAmount).to.deep.equal(toUint256WithFelts(1)); // 12% of 10 = 1.2 -> rounds down to 1
+    });
+  });
+
+  it("royaltyAmount calculation should be able to handle large salePrices", async function () {
+    await tryCatch(async () => {
+      const royaltyRecipient = BigInt(acc1.starknetContract.address);
+      const largeNum = new BN(
+        "100000000000000000000000000000000000000000000000"
+      );
+      const salePrice = toUint256WithFelts(largeNum);
+      const expectedRoyalty = largeNum.mul(new BN(1200)).div(new BN(10000));
+
+      const royalty = await contract.call("royaltyInfo", {
+        tokenId: toUint256WithFelts(1),
+        salePrice,
+      });
+      expect(royalty.receiver).to.deep.equal(royaltyRecipient);
+      expect(royalty.royaltyAmount).to.deep.equal(
+        toUint256WithFelts(expectedRoyalty)
+      ); // 12%
+    });
+  });
+
+  it("ContractOwner can reset a token royalty to use the default royalty info", async function () {
+    await tryCatch(async () => {
+      const royaltyRecipient = BigInt(acc1.starknetContract.address);
+      const salePrice = toUint256WithFelts(100);
+
+      await acc1.invoke(contract, "resetTokenRoyalty", {
+        tokenId: toUint256WithFelts(1),
+      });
+
+      let royalty = await contract.call("royaltyInfo", {
+        tokenId: toUint256WithFelts(1),
+        salePrice,
+      });
+      // token royalty for id 1 = (0, 0)
+      expect(royalty.receiver).to.deep.equal(royaltyRecipient);
+      expect(royalty.royaltyAmount).to.deep.equal(toUint256WithFelts(20)); // 20% of 100
+    });
+  });
+
+  it("ContractOwner can reset a default royalty", async function () {
+    await tryCatch(async () => {
+      const salePrice = toUint256WithFelts(100);
+
+      await acc1.invoke(contract, "resetDefaultRoyalty");
+
+      let royalty = await contract.call("royaltyInfo", {
+        tokenId: toUint256WithFelts(1),
+        salePrice,
+      });
+      // default royalty = (0, 0)
+      expect(royalty.receiver).to.deep.equal(BigInt(0));
+      expect(royalty.royaltyAmount).to.deep.equal(toUint256WithFelts(0));
+    });
+  });
+
+  it("ContractOwner can no longer set any royalty after resetting both royalties", async function () {
+    await tryCatch(async () => {
+      const recipient = BigInt(acc2.starknetContract.address);
+      const percentage = BigInt(2000); // 20%
+      const tokenId = toUint256WithFelts(2);
+      await shouldFail(
+        acc1.invoke(contract, "setTokenRoyalty", {
+          tokenId,
+          receiver: recipient,
+          feeBasisPoints: percentage,
+        }),
+        "ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points"
+      );
+
+      await shouldFail(
+        acc1.invoke(contract, "setDefaultRoyalty", {
+          receiver: recipient,
+          feeBasisPoints: percentage,
+        }),
+        "ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points"
+      );
+    });
+  });
+});

--- a/tests/functional/starknet/protostar/erc20/test_ERC20_Mintable_Capped.cairo
+++ b/tests/functional/starknet/protostar/erc20/test_ERC20_Mintable_Capped.cairo
@@ -1,0 +1,173 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from immutablex.starknet.token.erc20.interfaces.IERC20_Mintable_Capped import IERC20_Mintable_Capped
+from tests.utils.test_constants import TRUE, FALSE
+
+const NAME = 'CalCoin'
+const SYMBOL = 'CAL'
+const DECIMALS = 18
+const OWNER = 123456
+const CAP_LOW = 1000000
+const CAP_HIGH = 0
+
+@view
+func __setup__():
+    %{
+        context.contract_address = deploy_contract("./immutablex/starknet/token/erc20/presets/ERC20_Mintable_Capped.cairo", 
+            [
+                ids.NAME, ids.SYMBOL, ids.DECIMALS, ids.OWNER, ids.CAP_LOW, ids.CAP_HIGH
+            ]
+        ).contract_address
+    %}
+    return ()
+end
+
+@view
+func test_get_name{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (name) = IERC20_Mintable_Capped.name(contract_address)
+    assert NAME = name
+    return ()
+end
+
+@view
+func test_get_symbol{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (symbol) = IERC20_Mintable_Capped.symbol(contract_address)
+    assert SYMBOL = symbol
+    return ()
+end
+
+@view
+func test_get_decimals{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (decimals) = IERC20_Mintable_Capped.decimals(contract_address)
+    assert DECIMALS = decimals
+    return ()
+end
+
+@view
+func test_get_owner{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (owner) = IERC20_Mintable_Capped.owner(contract_address)
+    assert OWNER = owner
+    return ()
+end
+
+@view
+func test_get_cap{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (cap) = IERC20_Mintable_Capped.cap(contract_address)
+    assert CAP_LOW = cap.low
+    assert CAP_HIGH = cap.high
+    return ()
+end
+
+@view
+func test_owner_can_mint_tokens{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+    ):
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC20_Mintable_Capped.mint(contract_address, account, Uint256(100, 0))
+    %{ stop_prank_callable() %}
+
+    let (balance) = IERC20_Mintable_Capped.balanceOf(contract_address, account)
+    assert 100 = balance.low
+    assert 0 = balance.high
+    return ()
+end
+
+@view
+func test_non_owner_cannot_mint_tokens{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    %{ expect_revert(error_message="Ownable: caller is not the owner") %}
+    IERC20_Mintable_Capped.mint(contract_address, account, Uint256(100, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_cannot_mint_tokens_exceeding_maximum_supply_cap{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    # 1000001 > cap -> revert
+    %{ expect_revert(error_message="Capped: cap exceeded") %}
+    IERC20_Mintable_Capped.mint(contract_address, account, Uint256(1000001, 0))
+
+    # 100000 <= cap -> success
+    IERC20_Mintable_Capped.mint(contract_address, account, Uint256(1000000, 0))
+    let (balance) = IERC20_Mintable_Capped.balanceOf(contract_address, account)
+    assert 1000000 = balance.low
+    assert 0 = balance.high
+
+    # 1000000 + 1 > cap -> revert
+    %{ expect_revert(error_message="Capped: cap exceeded") %}
+    IERC20_Mintable_Capped.mint(contract_address, account, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_owner_can_transfer_contract_ownership{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let new_owner = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC20_Mintable_Capped.transferOwnership(contract_address, new_owner)
+    %{ stop_prank_callable() %}
+
+    let (owner) = IERC20_Mintable_Capped.owner(contract_address)
+    assert new_owner = owner
+    return ()
+end
+
+@view
+func test_previous_owner_cannot_transfer_contract_ownership{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let new_owner = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+
+    IERC20_Mintable_Capped.transferOwnership(contract_address, new_owner)
+    %{ expect_revert(error_message="Ownable: caller is not the owner") %}
+    IERC20_Mintable_Capped.transferOwnership(contract_address, OWNER)
+
+    %{ stop_prank_callable() %}
+    return ()
+end

--- a/tests/functional/starknet/protostar/erc721/test_Bridgeable.cairo
+++ b/tests/functional/starknet/protostar/erc721/test_Bridgeable.cairo
@@ -1,0 +1,150 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.alloc import alloc
+from immutablex.starknet.token.erc721.interfaces.IERC721 import IERC721
+from immutablex.starknet.access.IAccessControl import IAccessControl
+from immutablex.starknet.bridge.interfaces.IERC721_Bridgeable import IERC721_Bridgeable
+from tests.utils.test_constants import TRUE, FALSE
+
+const NAME = 'Rezs Raging Rhinos'
+const SYMBOL = 'REZ'
+const OWNER = 123456
+const ROYALTY_RECIPIENT = 567890
+const ROYALTY_FEE_BASIS_POINTS = 2000
+
+const MOCK_BRIDGE_ADDRESS = 1234567890
+
+@view
+func __setup__():
+    %{
+        context.contract_address = deploy_contract("./immutablex/starknet/token/erc721/presets/ERC721_Full.cairo", 
+            [
+                ids.NAME, ids.SYMBOL, ids.OWNER, ids.ROYALTY_RECIPIENT, ids.ROYALTY_FEE_BASIS_POINTS
+            ]
+        ).contract_address
+    %}
+    return ()
+end
+
+@view
+func test_default_admin_can_grant_a_bridge_minter_and_burner_roles{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (has_minter_role) = IAccessControl.hasRole(
+        contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS
+    )
+    assert FALSE = has_minter_role
+    let (has_burner_role) = IAccessControl.hasRole(
+        contract_address, 'BURNER_ROLE', MOCK_BRIDGE_ADDRESS
+    )
+    assert FALSE = has_burner_role
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IAccessControl.grantRole(contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS)
+    IAccessControl.grantRole(contract_address, 'BURNER_ROLE', MOCK_BRIDGE_ADDRESS)
+    %{ stop_prank_callable() %}
+
+    let (has_minter_role) = IAccessControl.hasRole(
+        contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS
+    )
+    assert TRUE = has_minter_role
+    let (has_burner_role) = IAccessControl.hasRole(
+        contract_address, 'BURNER_ROLE', MOCK_BRIDGE_ADDRESS
+    )
+    assert TRUE = has_burner_role
+    return ()
+end
+
+@view
+func test_unauthorized_bridge_address_cannot_call_permissioned_functions{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.MOCK_BRIDGE_ADDRESS, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC721_Bridgeable.permissionedMint(contract_address, account, Uint256(1, 0))
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC721_Bridgeable.permissionedBurn(contract_address, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_bridge_with_minter_role_can_call_permissionedMint{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IAccessControl.grantRole(contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS)
+    %{ stop_prank_callable() %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.MOCK_BRIDGE_ADDRESS, context.contract_address) %}
+    IERC721_Bridgeable.permissionedMint(contract_address, account, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (owner) = IERC721.ownerOf(contract_address, Uint256(1, 0))
+    assert account = owner
+    return ()
+end
+
+@view
+func test_bridge_with_burner_role_can_call_permissionedBurn{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IAccessControl.grantRole(contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS)
+    IAccessControl.grantRole(contract_address, 'BURNER_ROLE', MOCK_BRIDGE_ADDRESS)
+    %{ stop_prank_callable() %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.MOCK_BRIDGE_ADDRESS, context.contract_address) %}
+    IERC721_Bridgeable.permissionedMint(contract_address, account, Uint256(1, 0))
+    IERC721_Bridgeable.permissionedBurn(contract_address, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (balance) = IERC721.balanceOf(contract_address, account)
+    assert Uint256(0, 0) = balance
+    return ()
+end
+
+@view
+func test_default_admin_can_revoke_bridge_roles{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IAccessControl.grantRole(contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS)
+    IAccessControl.grantRole(contract_address, 'BURNER_ROLE', MOCK_BRIDGE_ADDRESS)
+
+    IAccessControl.revokeRole(contract_address, 'MINTER_ROLE', MOCK_BRIDGE_ADDRESS)
+    IAccessControl.revokeRole(contract_address, 'BURNER_ROLE', MOCK_BRIDGE_ADDRESS)
+    %{ stop_prank_callable() %}
+
+    %{ stop_prank_callable = start_prank(ids.MOCK_BRIDGE_ADDRESS, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC721_Bridgeable.permissionedMint(contract_address, account, Uint256(1, 0))
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC721_Bridgeable.permissionedBurn(contract_address, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end

--- a/tests/functional/starknet/protostar/erc721/test_ERC721.cairo
+++ b/tests/functional/starknet/protostar/erc721/test_ERC721.cairo
@@ -1,0 +1,250 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.alloc import alloc
+from immutablex.starknet.token.erc721.interfaces.IERC721 import IERC721
+from immutablex.starknet.token.erc721_token_metadata.interfaces.IERC721_Token_Metadata import (
+    IERC721_Token_Metadata,
+)
+from immutablex.starknet.access.IAccessControl import IAccessControl
+from immutablex.starknet.bridge.interfaces.IERC721_Bridgeable import IERC721_Bridgeable
+from tests.utils.test_constants import TRUE, FALSE
+
+const NAME = 'Rezs Raging Rhinos'
+const SYMBOL = 'REZ'
+const OWNER = 123456
+const ROYALTY_RECIPIENT = 567890
+const ROYALTY_FEE_BASIS_POINTS = 2000
+
+@view
+func __setup__():
+    %{
+        context.contract_address = deploy_contract("./immutablex/starknet/token/erc721/presets/ERC721_Full.cairo", 
+            [
+                ids.NAME, ids.SYMBOL, ids.OWNER, ids.ROYALTY_RECIPIENT, ids.ROYALTY_FEE_BASIS_POINTS
+            ]
+        ).contract_address
+    %}
+    return ()
+end
+
+@view
+func test_get_name{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (name) = IERC721.name(contract_address)
+    assert NAME = name
+    return ()
+end
+
+@view
+func test_get_symbol{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (symbol) = IERC721.symbol(contract_address)
+    assert SYMBOL = symbol
+    return ()
+end
+
+@view
+func test_has_role{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (has_default_admin_role) = IAccessControl.hasRole(contract_address, 0, OWNER)
+    assert TRUE = has_default_admin_role
+
+    let (has_minter_role) = IAccessControl.hasRole(contract_address, 'MINTER_ROLE', OWNER)
+    assert FALSE = has_minter_role
+    return ()
+end
+
+@view
+func test_account_with_minter_role_can_mint_tokens{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    test_utils.mint_token(contract_address, account, Uint256(1, 0))
+    test_utils.mint_token(contract_address, account, Uint256(2, 0))
+
+    let (balance) = IERC721.balanceOf(contract_address, account)
+    assert Uint256(2, 0) = balance
+    return ()
+end
+
+@view
+func test_account_without_minter_role_cannot_mint_tokens{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC721_Bridgeable.permissionedMint(contract_address, account, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_token_owner_can_transferFrom_their_NFT{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account_1 = 123
+    let account_2 = 456
+
+    test_utils.mint_token(contract_address, account_1, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.account_1, context.contract_address) %}
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (token_owner) = IERC721.ownerOf(contract_address, Uint256(1, 0))
+    assert account_2 = token_owner
+    return ()
+end
+
+@view
+func test_token_owner_can_approve_another_address_to_transfer_their_NFT{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account_1 = 123
+    let account_2 = 456
+
+    test_utils.mint_token(contract_address, account_1, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.account_1, context.contract_address) %}
+    IERC721.approve(contract_address, account_2, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (approved) = IERC721.getApproved(contract_address, Uint256(1, 0))
+    assert account_2 = approved
+
+    %{ stop_prank_callable = start_prank(ids.account_2, context.contract_address) %}
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (token_owner) = IERC721.ownerOf(contract_address, Uint256(1, 0))
+    assert account_2 = token_owner
+    return ()
+end
+
+@view
+func test_token_owner_can_approveForAll_another_address_to_transfer_all_their_NFTs{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account_1 = 123
+    let account_2 = 456
+
+    test_utils.mint_token(contract_address, account_1, Uint256(1, 0))
+    test_utils.mint_token(contract_address, account_1, Uint256(2, 0))
+    test_utils.mint_token(contract_address, account_1, Uint256(3, 0))
+
+    %{ stop_prank_callable = start_prank(ids.account_1, context.contract_address) %}
+    IERC721.setApprovalForAll(contract_address, account_2, TRUE)
+    %{ stop_prank_callable() %}
+
+    let (is_approved) = IERC721.isApprovedForAll(contract_address, account_1, account_2)
+    assert TRUE = is_approved
+
+    %{ stop_prank_callable = start_prank(ids.account_2, context.contract_address) %}
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(1, 0))
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(2, 0))
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(3, 0))
+    %{ stop_prank_callable() %}
+
+    let (balance) = IERC721.balanceOf(contract_address, account_1)
+    assert Uint256(0, 0) = balance
+    let (balance) = IERC721.balanceOf(contract_address, account_2)
+    assert Uint256(3, 0) = balance
+    return ()
+end
+
+@view
+func test_token_owner_can_revoke_approval_by_approving_zero_address{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account_1 = 123
+    let account_2 = 456
+
+    test_utils.mint_token(contract_address, account_1, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.account_1, context.contract_address) %}
+    IERC721.approve(contract_address, account_2, Uint256(1, 0))
+    IERC721.approve(contract_address, 0, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (approved) = IERC721.getApproved(contract_address, Uint256(1, 0))
+    assert 0 = approved
+
+    %{ stop_prank_callable = start_prank(ids.account_2, context.contract_address) %}
+    %{ expect_revert(error_message="ERC721: either is not approved or the caller is the zero address") %}
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_token_owner_can_revoke_approveForAll{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account_1 = 123
+    let account_2 = 456
+
+    test_utils.mint_token(contract_address, account_1, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.account_1, context.contract_address) %}
+    IERC721.setApprovalForAll(contract_address, account_2, TRUE)
+    IERC721.setApprovalForAll(contract_address, account_2, FALSE)
+    %{ stop_prank_callable() %}
+
+    let (is_approved) = IERC721.isApprovedForAll(contract_address, account_1, account_2)
+    assert 0 = is_approved
+
+    %{ stop_prank_callable = start_prank(ids.account_2, context.contract_address) %}
+    %{ expect_revert(error_message="ERC721: either is not approved or the caller is the zero address") %}
+    IERC721.transferFrom(contract_address, account_1, account_2, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+namespace test_utils:
+    func mint_token{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        contract_address : felt, to : felt, token_id : Uint256
+    ):
+        %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+        IAccessControl.grantRole(contract_address, 'MINTER_ROLE', OWNER)
+        IERC721_Bridgeable.permissionedMint(contract_address, to, token_id)
+        %{ stop_prank_callable() %}
+        return ()
+    end
+end

--- a/tests/functional/starknet/protostar/erc721/test_ERC721_Metadata.cairo
+++ b/tests/functional/starknet/protostar/erc721/test_ERC721_Metadata.cairo
@@ -1,0 +1,255 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.alloc import alloc
+from immutablex.starknet.token.erc721.interfaces.IERC721 import IERC721
+from immutablex.starknet.token.erc721_token_metadata.interfaces.IERC721_Token_Metadata import (
+    IERC721_Token_Metadata,
+)
+from immutablex.starknet.token.erc721_contract_metadata.interfaces.IERC721_Contract_Metadata import (
+    IERC721_Contract_Metadata,
+)
+from immutablex.starknet.access.IAccessControl import IAccessControl
+from immutablex.starknet.bridge.interfaces.IERC721_Bridgeable import IERC721_Bridgeable
+from tests.utils.test_constants import TRUE, FALSE
+
+const NAME = 'Rezs Raging Rhinos'
+const SYMBOL = 'REZ'
+const OWNER = 123456
+const ROYALTY_RECIPIENT = 567890
+const ROYALTY_FEE_BASIS_POINTS = 2000
+
+@view
+func __setup__():
+    %{
+        context.contract_address = deploy_contract("./immutablex/starknet/token/erc721/presets/ERC721_Full.cairo", 
+            [
+                ids.NAME, ids.SYMBOL, ids.OWNER, ids.ROYALTY_RECIPIENT, ids.ROYALTY_FEE_BASIS_POINTS
+            ]
+        ).contract_address
+    %}
+    return ()
+end
+
+@view
+func test_account_with_admin_role_can_set_base_uri{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+    let (base_uri : felt*) = alloc()
+    assert base_uri[0] = 'https://ipfs.io/ipfs/this-is-a-'
+    assert base_uri[1] = 'reasonable-sized-base-uri-set-b'
+    assert base_uri[2] = 'y-the-owner/'
+
+    test_utils.mint_token(contract_address, account, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC721_Token_Metadata.setBaseURI(contract_address, 3, base_uri)
+    %{ stop_prank_callable() %}
+
+    let (token_uri_len, token_uri) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(1, 0)
+    )
+    assert 4 = token_uri_len
+    assert base_uri[0] = token_uri[0]
+    assert base_uri[1] = token_uri[1]
+    assert base_uri[2] = token_uri[2]
+    assert '1' = token_uri[3]
+    return ()
+end
+
+@view
+func test_get_token_uri_for_token_with_undefined_token_uri_returns_empty_array{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let (token_uri_len, token_uri) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(1, 0)
+    )
+    assert 0 = token_uri_len
+    return ()
+end
+
+@view
+func test_revert_get_token_uri_for_nonexistent_token{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    %{ expect_revert(error_message="ERC721_Token_Metadata: URI query for nonexistent token") %}
+    let (token_uri_len, token_uri) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(1, 0)
+    )
+    return ()
+end
+
+@view
+func test_account_with_admin_role_can_set_token_uri_to_override_base_uri{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+    let (base_uri : felt*) = alloc()
+    assert base_uri[0] = 'base-uri/'
+
+    test_utils.mint_token(contract_address, account, Uint256(1, 0))
+    test_utils.mint_token(contract_address, account, Uint256(2, 0))
+
+    let (input_token_uri : felt*) = alloc()
+    assert input_token_uri[0] = 'https://ipfs.io/ipfs/this-NFT-h'
+    assert input_token_uri[1] = 'as-tokenId-set'
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC721_Token_Metadata.setBaseURI(contract_address, 1, base_uri)
+    IERC721_Token_Metadata.setTokenURI(contract_address, Uint256(1, 0), 2, input_token_uri)
+    %{ stop_prank_callable() %}
+
+    # Token ID 1 should have a new token uri returned
+    let (token_uri_len_1, token_uri_1) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(1, 0)
+    )
+    assert 2 = token_uri_len_1
+    assert input_token_uri[0] = token_uri_1[0]
+    assert input_token_uri[1] = token_uri_1[1]
+
+    # Token ID 2 should still return the base uri + token id
+    let (token_uri_len_2, token_uri_2) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(2, 0)
+    )
+    assert 2 = token_uri_len_2
+    assert base_uri[0] = token_uri_2[0]
+    assert '2' = token_uri_2[1]
+    return ()
+end
+
+@view
+func test_account_with_admin_role_can_reset_token_uri_to_use_base_uri_again{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+    let (base_uri : felt*) = alloc()
+    assert base_uri[0] = 'base-uri/'
+
+    let (input_token_uri : felt*) = alloc()
+    assert input_token_uri[0] = 'https://ipfs.io/ipfs/this-NFT-h'
+    assert input_token_uri[1] = 'as-tokenId-set'
+
+    test_utils.mint_token(contract_address, account, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC721_Token_Metadata.setBaseURI(contract_address, 1, base_uri)
+    IERC721_Token_Metadata.setTokenURI(contract_address, Uint256(1, 0), 2, input_token_uri)
+    IERC721_Token_Metadata.resetTokenURI(contract_address, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (token_uri_len, token_uri) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(1, 0)
+    )
+    assert 2 = token_uri_len
+    assert base_uri[0] = token_uri[0]
+    assert '1' = token_uri[1]
+    return ()
+end
+
+@view
+func test_can_set_ASCII_character_set_in_base_uri{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+    let (base_uri : felt*) = alloc()
+    assert base_uri[0] = 'https://() !"[~^.Za1234567890Ab'
+    assert base_uri[1] = 'cDseksicmab'
+
+    test_utils.mint_token(contract_address, account, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC721_Token_Metadata.setBaseURI(contract_address, 2, base_uri)
+    %{ stop_prank_callable() %}
+
+    let (token_uri_len, token_uri) = IERC721_Token_Metadata.tokenURI(
+        contract_address, Uint256(1, 0)
+    )
+    assert 3 = token_uri_len
+    assert base_uri[0] = token_uri[0]
+    assert base_uri[1] = token_uri[1]
+    assert '1' = token_uri[2]
+    return ()
+end
+
+@view
+func test_account_with_admin_role_can_set_contract_uri{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (input_contract_uri : felt*) = alloc()
+    assert input_contract_uri[0] = 'https://ipfs.io/ipfs/the-owner-'
+    assert input_contract_uri[1] = 'is-trying-set-a-reasonable-size'
+    assert input_contract_uri[2] = 'd-contract-uri/'
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC721_Contract_Metadata.setContractURI(contract_address, 3, input_contract_uri)
+    %{ stop_prank_callable() %}
+
+    let (contract_uri_len, contract_uri) = IERC721_Contract_Metadata.contractURI(contract_address)
+    assert 3 = contract_uri_len
+    assert input_contract_uri[0] = contract_uri[0]
+    assert input_contract_uri[1] = contract_uri[1]
+    assert input_contract_uri[2] = contract_uri[2]
+    return ()
+end
+
+@view
+func test_account_without_admin_role_cannot_set_contract_uri{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let account = 123
+    let (input_contract_uri : felt*) = alloc()
+    assert input_contract_uri[0] = 'https://ipfs.io/ipfs/the-owner-'
+    assert input_contract_uri[1] = 'is-trying-set-a-reasonable-size'
+    assert input_contract_uri[2] = 'd-contract-uri/'
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC721_Contract_Metadata.setContractURI(contract_address, 3, input_contract_uri)
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+namespace test_utils:
+    func mint_token{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        contract_address : felt, to : felt, token_id : Uint256
+    ):
+        %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+        IAccessControl.grantRole(contract_address, 'MINTER_ROLE', OWNER)
+        IERC721_Bridgeable.permissionedMint(contract_address, to, token_id)
+        %{ stop_prank_callable() %}
+        return ()
+    end
+end

--- a/tests/functional/starknet/protostar/erc721/test_Royalties.cairo
+++ b/tests/functional/starknet/protostar/erc721/test_Royalties.cairo
@@ -1,0 +1,392 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.alloc import alloc
+from immutablex.starknet.token.erc721.interfaces.IERC721 import IERC721
+from immutablex.starknet.access.IAccessControl import IAccessControl
+from immutablex.starknet.bridge.interfaces.IERC721_Bridgeable import IERC721_Bridgeable
+from immutablex.starknet.auxiliary.erc2981.interfaces.IERC2981_Unidirectional import (
+    IERC2981_Unidirectional,
+)
+from tests.utils.test_constants import TRUE, FALSE
+
+const NAME = 'Rezs Raging Rhinos'
+const SYMBOL = 'REZ'
+const OWNER = 123456
+const ROYALTY_RECIPIENT = 567890
+const ROYALTY_FEE_BASIS_POINTS = 2000  # 20% default royalty
+
+@view
+func __setup__():
+    %{
+        context.contract_address = deploy_contract("./immutablex/starknet/token/erc721/presets/ERC721_Full.cairo", 
+            [
+                ids.NAME, ids.SYMBOL, ids.OWNER, ids.ROYALTY_RECIPIENT, ids.ROYALTY_FEE_BASIS_POINTS
+            ]
+        ).contract_address
+    %}
+    return ()
+end
+
+@view
+func test_get_default_royalty{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (receiver, feeBasisPoints) = IERC2981_Unidirectional.getDefaultRoyalty(contract_address)
+    assert ROYALTY_RECIPIENT = receiver
+    assert ROYALTY_FEE_BASIS_POINTS = feeBasisPoints
+    return ()
+end
+
+@view
+func test_non_admin_cannot_set_royalty_details{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let account = 123
+    let fee_basis_points = 1900  # 19%
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC2981_Unidirectional.setDefaultRoyalty(contract_address, account, fee_basis_points)
+
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), account, fee_basis_points
+    )
+
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_can_set_default_royalty_lower_than_current_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let fee_basis_points = 1999  # 19.99%
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.setDefaultRoyalty(contract_address, ROYALTY_RECIPIENT, fee_basis_points)
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert ROYALTY_RECIPIENT = receiver
+    assert Uint256(1999, 0) = royaltyAmount  # 19.99% of 10,000
+    return ()
+end
+
+@view
+func test_can_change_royalty_recipient_for_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let new_receiver = 123
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.setDefaultRoyalty(
+        contract_address, new_receiver, ROYALTY_FEE_BASIS_POINTS
+    )
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert new_receiver = receiver
+    assert Uint256(2000, 0) = royaltyAmount
+    return ()
+end
+
+@view
+func test_can_reset_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.resetDefaultRoyalty(contract_address)
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert 0 = receiver
+    assert Uint256(0, 0) = royaltyAmount
+    return ()
+end
+
+@view
+func test_cannot_increase_royalty_percentage_after_resetting_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.resetDefaultRoyalty(contract_address)
+
+    let fee_basis_points = 1
+    %{ expect_revert(error_message="ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points") %}
+    IERC2981_Unidirectional.setDefaultRoyalty(contract_address, ROYALTY_RECIPIENT, fee_basis_points)
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_can_set_a_token_specific_royalty_lower_than_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let input_receiver = 123
+    let fee_basis_points = 1500  # 15%
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert input_receiver = receiver
+    assert Uint256(1500, 0) = royaltyAmount  # 15% of 10,000
+    return ()
+end
+
+@view
+func test_can_set_a_token_specific_royalty_equal_to_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let input_receiver = 123
+    let fee_basis_points = 2000  # 20%
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert input_receiver = receiver
+    assert Uint256(2000, 0) = royaltyAmount  # 20% of 10,000
+    return ()
+end
+
+@view
+func test_can_change_royalty_recipient_for_token_specific_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let input_receiver_1 = 123
+    let input_receiver_2 = 456
+    let fee_basis_points = 1800  # 18%
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver_1, fee_basis_points
+    )
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver_2, fee_basis_points
+    )
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert input_receiver_2 = receiver
+    assert Uint256(1800, 0) = royaltyAmount  # 18% of 10,000
+    return ()
+end
+
+@view
+func test_cannot_set_a_token_specific_royalty_higher_than_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let input_receiver = 123
+    let fee_basis_points = 2001  # 20.01%
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    %{ expect_revert(error_message="ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points") %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_cannot_set_a_token_specific_royalty_higher_than_existing_token_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    let input_receiver = 123
+    let fee_basis_points = 1500  # 15%
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+
+    let input_receiver = 123
+    let fee_basis_points = 1550  # 15.5%
+    %{ expect_revert(error_message="ERC2981_UniDirectional_Mutable: new fee_basis_points exceeds current fee_basis_points") %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_cannot_set_a_token_specific_royalty_for_nonexistent_token{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+
+    let input_receiver = 123
+    let fee_basis_points = 2100  # 21%
+
+    %{ expect_revert(error_message="token ID does not exist") %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_can_reset_token_specific_royalty_to_use_default_royalty{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let input_receiver = 123
+    let fee_basis_points = 1500  # 15%
+
+    %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+    IERC2981_Unidirectional.setTokenRoyalty(
+        contract_address, Uint256(1, 0), input_receiver, fee_basis_points
+    )
+    IERC2981_Unidirectional.resetTokenRoyalty(contract_address, Uint256(1, 0))
+    %{ stop_prank_callable() %}
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(10000, 0)
+    )
+    assert ROYALTY_RECIPIENT = receiver
+    assert Uint256(2000, 0) = royaltyAmount  # 20% of 10,000
+    return ()
+end
+
+# EIP-2981 states that implementers may choose round down or up to nearest integer
+# This implementation (currently) always rounds down
+@view
+func test_get_royalty_info_should_round_down_when_not_exactly_divisible{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(123, 0)
+    )
+    assert ROYALTY_RECIPIENT = receiver
+    assert Uint256(24, 0) = royaltyAmount  # 20% of 123 = 24.6 = 24 rounded down
+    return ()
+end
+
+@view
+func test_get_royalty_info_can_handle_large_sale_prices{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local contract_address
+    %{ ids.contract_address = context.contract_address %}
+    test_utils.mint_token(contract_address, OWNER, Uint256(1, 0))
+
+    let (receiver, royaltyAmount) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(1000000000, 1000000000)
+    )
+    assert ROYALTY_RECIPIENT = receiver
+    assert Uint256(200000000, 200000000) = royaltyAmount
+    return ()
+end
+
+@view
+func test_revert_get_royalty_info_for_nonexistent_tokens{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    %{ expect_revert(error_message="token ID does not exist") %}
+    let (receiver, feeBasisPoints) = IERC2981_Unidirectional.royaltyInfo(
+        contract_address, Uint256(1, 0), Uint256(100, 0)
+    )
+    return ()
+end
+
+namespace test_utils:
+    func mint_token{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}(
+        contract_address : felt, to : felt, token_id : Uint256
+    ):
+        %{ stop_prank_callable = start_prank(ids.OWNER, context.contract_address) %}
+        IAccessControl.grantRole(contract_address, 'MINTER_ROLE', OWNER)
+        IERC721_Bridgeable.permissionedMint(contract_address, to, token_id)
+        %{ stop_prank_callable() %}
+        return ()
+    end
+end

--- a/tests/functional/starknet/protostar/test_AccessControl.cairo
+++ b/tests/functional/starknet/protostar/test_AccessControl.cairo
@@ -1,0 +1,294 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from immutablex.starknet.mocks.IAccessControl_mock import IAccessControl
+from tests.utils.test_constants import TRUE, FALSE
+
+const DEFAULT_ADMIN_ACCOUNT = 123456
+const DEFAULT_ADMIN_ROLE = 0
+
+@view
+func __setup__():
+    %{ context.contract_address = deploy_contract("./immutablex/starknet/mocks/AccessControl_mock.cairo", [ids.DEFAULT_ADMIN_ACCOUNT]).contract_address %}
+    return ()
+end
+
+@view
+func test_default_admin_should_have_default_admin_role{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let (has_admin_role) = IAccessControl.has_role(
+        contract_address, DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ACCOUNT
+    )
+    assert TRUE = has_admin_role
+    return ()
+end
+
+@view
+func test_non_default_admin_should_not_have_default_admin_role{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let non_admin_account = 123
+
+    let (has_admin_role) = IAccessControl.has_role(
+        contract_address, DEFAULT_ADMIN_ROLE, non_admin_account
+    )
+    assert FALSE = has_admin_role
+    return ()
+end
+
+@view
+func test_default_admin_can_grant_a_new_role_to_an_account{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let account = 123
+
+    %{ expect_events({"name": "RoleGranted", "data": [ids.minter_role, ids.account, ids.DEFAULT_ADMIN_ACCOUNT]}) %}
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+    IAccessControl.grant_role(contract_address, minter_role, account)
+    %{ stop_prank_callable() %}
+
+    let (has_minter_role) = IAccessControl.has_role(contract_address, minter_role, account)
+    assert TRUE = has_minter_role
+    return ()
+end
+
+@view
+func test_non_role_admin_cannot_grant_new_roles{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IAccessControl.grant_role(contract_address, minter_role, account)
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_role_admin_can_revoke_roles_from_account{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let account = 123
+
+    %{ expect_events({"name": "RoleRevoked", "data": [ids.minter_role, ids.account, ids.DEFAULT_ADMIN_ACCOUNT]}) %}
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+
+    IAccessControl.grant_role(contract_address, minter_role, account)
+    let (has_minter_role) = IAccessControl.has_role(contract_address, minter_role, account)
+    assert TRUE = has_minter_role
+
+    IAccessControl.revoke_role(contract_address, minter_role, account)
+    let (has_minter_role) = IAccessControl.has_role(contract_address, minter_role, account)
+    assert FALSE = has_minter_role
+
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_non_role_admin_cannot_revoke_roles_from_account{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+
+    IAccessControl.revoke_role(contract_address, minter_role, account)
+
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_default_admin_can_set_a_role_admin{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let minter_role_admin = 'MINTER_ROLE_ADMIN'
+
+    let (role_admin) = IAccessControl.get_role_admin(contract_address, minter_role)
+    assert DEFAULT_ADMIN_ROLE = role_admin
+
+    %{ expect_events({"name": "RoleAdminChanged", "data": [ids.minter_role, ids.DEFAULT_ADMIN_ROLE, ids.minter_role_admin]}) %}
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+    IAccessControl.set_role_admin(contract_address, minter_role, minter_role_admin)
+    %{ stop_prank_callable() %}
+
+    let (role_admin) = IAccessControl.get_role_admin(contract_address, minter_role)
+    assert minter_role_admin = role_admin
+    return ()
+end
+
+@view
+func test_non_role_admin_cannot_set_role_admin{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let minter_role_admin = 'MINTER_ROLE_ADMIN'
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+
+    IAccessControl.set_role_admin(contract_address, minter_role, minter_role_admin)
+
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_default_admin_cannot_grant_role_for_which_another_role_admin_has_been_defined{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let minter_role_admin = 'MINTER_ROLE_ADMIN'
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+
+    IAccessControl.set_role_admin(contract_address, minter_role, minter_role_admin)
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IAccessControl.grant_role(contract_address, minter_role, account)
+
+    %{ stop_prank_callable() %}
+
+    return ()
+end
+
+@view
+func test_role_admin_can_manage_roles_for_which_they_are_an_admin{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let minter_role_admin = 'MINTER_ROLE_ADMIN'
+    let minter_role_account = 123
+    let account = 456
+
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+    IAccessControl.set_role_admin(contract_address, minter_role, minter_role_admin)
+    IAccessControl.grant_role(contract_address, minter_role_admin, minter_role_account)
+    %{ stop_prank_callable() %}
+
+    %{ stop_prank_callable = start_prank(ids.minter_role_account, context.contract_address) %}
+
+    IAccessControl.grant_role(contract_address, minter_role, account)
+    let (has_minter_role) = IAccessControl.has_role(contract_address, minter_role, account)
+    assert TRUE = has_minter_role
+
+    IAccessControl.revoke_role(contract_address, minter_role, account)
+    let (has_minter_role2) = IAccessControl.has_role(contract_address, minter_role, account)
+    assert FALSE = has_minter_role2
+
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_role_admin_cannot_manage_roles_for_which_it_is_not_an_admin{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let minter_role_admin = 'MINTER_ROLE_ADMIN'
+    let minter_role_account = 123
+    let account = 456
+
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+    IAccessControl.set_role_admin(contract_address, minter_role, minter_role_admin)
+    IAccessControl.grant_role(contract_address, minter_role_admin, minter_role_account)
+    %{ stop_prank_callable() %}
+
+    %{ stop_prank_callable = start_prank(ids.minter_role_account, context.contract_address) %}
+
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IAccessControl.grant_role(contract_address, DEFAULT_ADMIN_ROLE, account)
+    %{ expect_revert(error_message="AccessControl: account is missing role") %}
+    IAccessControl.revoke_role(contract_address, DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ACCOUNT)
+
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@view
+func test_role_member_can_renounce_role_for_self{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let account = 123
+
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+    IAccessControl.grant_role(contract_address, minter_role, account)
+    %{ stop_prank_callable() %}
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    IAccessControl.renounce_role(contract_address, minter_role, account)
+    %{ stop_prank_callable() %}
+
+    let (has_minter_role) = IAccessControl.has_role(contract_address, minter_role, account)
+    assert FALSE = has_minter_role
+    return ()
+end
+
+@view
+func test_role_member_cannot_renounce_role_for_other_accounts{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar contract_address
+    %{ ids.contract_address = context.contract_address %}
+
+    let minter_role = 'MINTER_ROLE'
+    let account = 123
+    let account2 = 456
+
+    %{ stop_prank_callable = start_prank(ids.DEFAULT_ADMIN_ACCOUNT, context.contract_address) %}
+    IAccessControl.grant_role(contract_address, minter_role, account)
+    IAccessControl.grant_role(contract_address, minter_role, account2)
+    %{ stop_prank_callable() %}
+
+    %{ stop_prank_callable = start_prank(ids.account, context.contract_address) %}
+    %{ expect_revert(error_message="AccessControl: can only renounce roles for self") %}
+    IAccessControl.renounce_role(contract_address, minter_role, account2)
+    %{ stop_prank_callable() %}
+    return ()
+end

--- a/tests/functional/starknet/protostar/test_PaymentSplitter.cairo
+++ b/tests/functional/starknet/protostar/test_PaymentSplitter.cairo
@@ -1,0 +1,298 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from immutablex.starknet.finance.IPaymentSplitter import IPaymentSplitter
+from immutablex.starknet.token.erc20.interfaces.IERC20_Mintable_Capped import IERC20_Mintable_Capped
+from tests.utils.test_constants import TRUE, FALSE
+
+const PAYEE_ACCOUNT_1 = 123
+const PAYEE_SHARES_1 = 150
+const PAYEE_ACCOUNT_2 = 456
+const PAYEE_SHARES_2 = 50
+const ERC20_OWNER = 789
+
+@view
+func __setup__():
+    %{
+        context.splitter_contract = deploy_contract("./immutablex/starknet/finance/PaymentSplitter.cairo", 
+            [
+                2, ids.PAYEE_ACCOUNT_1, ids.PAYEE_ACCOUNT_2,
+                2, ids.PAYEE_SHARES_1, ids.PAYEE_SHARES_2
+            ]
+        ).contract_address
+        context.erc20_contract = deploy_contract("./immutablex/starknet/token/erc20/presets/ERC20_Mintable_Capped.cairo", 
+            [
+                111111, 111, 18, ids.ERC20_OWNER, 1000000, 0
+            ]
+        ).contract_address
+    %}
+    return ()
+end
+
+@view
+func test_get_total_shares{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar splitter_contract
+    %{ ids.splitter_contract = context.splitter_contract %}
+
+    let (total_shares) = IPaymentSplitter.totalShares(splitter_contract)
+    assert 200 = total_shares
+    return ()
+end
+
+@view
+func test_get_payee_by_index{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar splitter_contract
+    %{ ids.splitter_contract = context.splitter_contract %}
+
+    let (payee_0) = IPaymentSplitter.payee(splitter_contract, 0)
+    assert PAYEE_ACCOUNT_2 = payee_0
+
+    let (payee_1) = IPaymentSplitter.payee(splitter_contract, 1)
+    assert PAYEE_ACCOUNT_1 = payee_1
+    return ()
+end
+
+@view
+func test_get_payee_count{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar splitter_contract
+    %{ ids.splitter_contract = context.splitter_contract %}
+
+    let (payee_count) = IPaymentSplitter.payeeCount(splitter_contract)
+    assert 2 = payee_count
+    return ()
+end
+
+@view
+func test_get_shares_by_payee{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    tempvar splitter_contract
+    %{ ids.splitter_contract = context.splitter_contract %}
+
+    let (shares_0) = IPaymentSplitter.shares(splitter_contract, PAYEE_ACCOUNT_1)
+    assert 150 = shares_0
+
+    let (shares_1) = IPaymentSplitter.shares(splitter_contract, PAYEE_ACCOUNT_2)
+    assert 50 = shares_1
+    return ()
+end
+
+@view
+func test_get_balance_by_token{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(100, 0))
+
+    let (balance) = IPaymentSplitter.balance(splitter_contract, erc20_contract)
+    assert 100 = balance.low
+    assert 0 = balance.high
+    return ()
+end
+
+@view
+func test_get_pending_payment_balance{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(100, 0))
+
+    let (pending_payment_1) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_1
+    )
+    assert 75 = pending_payment_1.low
+    assert 0 = pending_payment_1.high
+    let (pending_payment_2) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_2
+    )
+    assert 25 = pending_payment_2.low
+    assert 0 = pending_payment_2.high
+    return ()
+end
+
+@view
+func test_revert_get_pending_payment_for_non_existent_token{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    tempvar splitter_contract
+    %{ ids.splitter_contract = context.splitter_contract %}
+
+    let non_existent_token = 99999
+
+    %{ expect_revert(error_message="PaymentSplitter: Failed to call balanceOf on token contract") %}
+    let (pending_payment) = IPaymentSplitter.pendingPayment(
+        splitter_contract, non_existent_token, PAYEE_ACCOUNT_1
+    )
+    return ()
+end
+
+@view
+func test_revert_get_pending_payment_for_non_payee{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(100, 0))
+
+    let non_payee = 888
+
+    %{ expect_revert(error_message="PaymentSplitter: payee has no shares") %}
+    let (pending_payment) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, non_payee
+    )
+    return ()
+end
+
+@view
+func test_release_payment{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(100, 0))
+
+    %{ expect_events({"name": "PaymentReleased", "data": [ids.erc20_contract, ids.PAYEE_ACCOUNT_1, 75, 0]}) %}
+    IPaymentSplitter.release(splitter_contract, erc20_contract, PAYEE_ACCOUNT_1)
+
+    let (pending_payment) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_1
+    )
+    assert 0 = pending_payment.low
+    assert 0 = pending_payment.high
+
+    let (released) = IPaymentSplitter.released(splitter_contract, erc20_contract, PAYEE_ACCOUNT_1)
+    assert 75 = released.low
+    assert 0 = released.high
+
+    let (total_released) = IPaymentSplitter.totalReleased(splitter_contract, erc20_contract)
+    assert 75 = total_released.low
+    assert 0 = total_released.high
+
+    let (payee_balance) = IERC20_Mintable_Capped.balanceOf(erc20_contract, PAYEE_ACCOUNT_1)
+    assert 75 = payee_balance.low
+    assert 0 = payee_balance.high
+    return ()
+end
+
+@view
+func test_revert_release_payment_for_non_payee{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(100, 0))
+
+    let non_payee = 888
+
+    %{ expect_revert(error_message="PaymentSplitter: payee has no shares") %}
+    IPaymentSplitter.release(splitter_contract, erc20_contract, non_payee)
+    return ()
+end
+
+@view
+func test_revert_release_payment_for_no_pending_payment_amount{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    tempvar erc20_contract
+    tempvar splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+
+    %{ expect_revert(error_message="PaymentSplitter: payee is not due any payment") %}
+    IPaymentSplitter.release(splitter_contract, erc20_contract, PAYEE_ACCOUNT_1)
+    return ()
+end
+
+@view
+func test_pending_payment_calculations_after_released_payment{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(100, 0))
+
+    IPaymentSplitter.release(splitter_contract, erc20_contract, PAYEE_ACCOUNT_1)
+
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(200, 0))
+
+    let (pending_payment_1) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_1
+    )
+    assert 150 = pending_payment_1.low
+    assert 0 = pending_payment_1.high
+    let (pending_payment_2) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_2
+    )
+    assert 75 = pending_payment_2.low
+    assert 0 = pending_payment_2.high
+    return ()
+end
+
+@view
+func test_pending_payment_rounds_down_for_fee_splits_that_are_not_exactly_divisble{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    alloc_locals
+    local erc20_contract
+    local splitter_contract
+    %{
+        ids.erc20_contract = context.erc20_contract
+        ids.splitter_contract = context.splitter_contract
+    %}
+    test_utils.send_payment_to_splitter(splitter_contract, erc20_contract, Uint256(15, 0))
+
+    let (pending_payment_1) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_1
+    )
+    # (15 * (150/200 shares)) = 11.25 = 11 rounded down
+    assert 11 = pending_payment_1.low
+    assert 0 = pending_payment_1.high
+
+    let (pending_payment_2) = IPaymentSplitter.pendingPayment(
+        splitter_contract, erc20_contract, PAYEE_ACCOUNT_2
+    )
+    # (15 * (50/200 shares)) = 3.75 = 3 rounded down
+    assert 3 = pending_payment_2.low
+    assert 0 = pending_payment_2.high
+    return ()
+end
+
+namespace test_utils:
+    func send_payment_to_splitter{
+        syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+    }(splitter : felt, erc20 : felt, amount : Uint256):
+        %{ stop_prank_callable = start_prank(ids.ERC20_OWNER, context.erc20_contract) %}
+        IERC20_Mintable_Capped.mint(erc20, splitter, amount)
+        %{ stop_prank_callable() %}
+        return ()
+    end
+end

--- a/tests/utils/test_constants.cairo
+++ b/tests/utils/test_constants.cairo
@@ -1,0 +1,4 @@
+%lang starknet
+
+const TRUE = 1
+const FALSE = 0


### PR DESCRIPTION
### Added

- Protostar tests
- Added `IAccessControl_mock.cairo` for testing
- Added `name()` and `symbol()` to `IERC721` for testing

### Changed

- Upgrade to support OpenZeppelin 0.2.0
- `IERC2981_Unidirectional_Royalties` is now `IERC721_Unidirectional`

### Fixed

- `PaymentSplitter` now starts index from 0 instead of 1
- `ERC721_Token_Metadata` now returns empty felt array when both base and token uri are undefined
